### PR TITLE
strip Request mimetype

### DIFF
--- a/openapi_core/contrib/requests/requests.py
+++ b/openapi_core/contrib/requests/requests.py
@@ -80,7 +80,7 @@ class RequestsOpenAPIRequest:
         return str(
             self.request.headers.get("Content-Type")
             or self.request.headers.get("Accept")
-        )
+        ).split(";")[0]
 
 
 class RequestsOpenAPIWebhookRequest(RequestsOpenAPIRequest):

--- a/tests/unit/contrib/requests/conftest.py
+++ b/tests/unit/contrib/requests/conftest.py
@@ -14,12 +14,18 @@ def request_factory():
     schema = "http"
     server_name = "localhost"
 
-    def create_request(method, path, subdomain=None, query_string=""):
+    def create_request(
+        method,
+        path,
+        subdomain=None,
+        query_string="",
+        content_type="application/json",
+    ):
         base_url = "://".join([schema, server_name])
         url = urljoin(base_url, path)
         params = parse_qs(query_string)
         headers = {
-            "Content-Type": "application/json",
+            "Content-Type": content_type,
         }
         return Request(method, url, params=params, headers=headers)
 

--- a/tests/unit/contrib/requests/test_requests_requests.py
+++ b/tests/unit/contrib/requests/test_requests_requests.py
@@ -115,3 +115,30 @@ class TestRequestsOpenAPIRequest:
         assert openapi_request.path == "/browse/#12"
         assert openapi_request.body == prepared.body
         assert openapi_request.mimetype == "application/json"
+
+    def test_content_type_with_charset(self, request_factory, request):
+        request = request_factory(
+            "GET",
+            "/",
+            subdomain="www",
+            content_type="application/json; charset=utf-8",
+        )
+
+        openapi_request = RequestsOpenAPIRequest(request)
+
+        path = {}
+        query = ImmutableMultiDict([])
+        headers = Headers(dict(request.headers))
+        cookies = {}
+        prepared = request.prepare()
+        assert openapi_request.parameters == RequestParameters(
+            path=path,
+            query=query,
+            header=headers,
+            cookie=cookies,
+        )
+        assert openapi_request.method == request.method.lower()
+        assert openapi_request.host_url == "http://localhost"
+        assert openapi_request.path == "/"
+        assert openapi_request.body == prepared.body
+        assert openapi_request.mimetype == "application/json"


### PR DESCRIPTION
Strip [valid](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) commends to prevent 
```
openapi_core.validation.response.exceptions.DataValidationError: DataValidationError: Content for the following mimetype not found: application/json; charset=utf-8. Valid mimetypes: ['application/json']"
``` 