### PR TITLE
jsonschema 4.18 compatibility

### DIFF
--- a/openapi_core/validation/schemas/factories.py
+++ b/openapi_core/validation/schemas/factories.py
@@ -63,7 +63,7 @@ class SchemaValidatorsFactory:
         with schema.open() as schema_dict:
             jsonschema_validator = self.schema_validator_class(
                 schema_dict,
-                resolver=resolver,
+                _resolver=resolver,
                 format_checker=format_checker,
             )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -998,20 +998,22 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.17.3"
+version = "4.18.0a10"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "jsonschema-4.17.3-py3-none-any.whl", hash = "sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6"},
-    {file = "jsonschema-4.17.3.tar.gz", hash = "sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d"},
+    {file = "jsonschema-4.18.0a10-py3-none-any.whl", hash = "sha256:1b0ae112eb7a9681cc0a2a83eabf564b62417128d9c2dbd940eb410d20a8bbb9"},
+    {file = "jsonschema-4.18.0a10.tar.gz", hash = "sha256:7641e516a53ac67221a8045eccf11ba30312f9c28e173c911b84561f6f17fccb"},
 ]
 
 [package.dependencies]
-attrs = ">=17.4.0"
+attrs = ">=22.2.0"
 importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
+jsonschema-specifications = ">=2023.03.6"
 pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
-pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+referencing = ">=0.28.4"
+rpds-py = ">=0.7.1"
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
@@ -1019,20 +1021,35 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "jsonschema-spec"
-version = "0.1.6"
+version = "0.2.2"
 description = "JSONSchema Spec with object-oriented paths"
 optional = false
-python-versions = ">=3.7.0,<4.0.0"
+python-versions = ">=3.8.0,<4.0.0"
 files = [
-    {file = "jsonschema_spec-0.1.6-py3-none-any.whl", hash = "sha256:f2206d18c89d1824c1f775ba14ed039743b41a9167bd2c5bdb774b66b3ca0bbf"},
-    {file = "jsonschema_spec-0.1.6.tar.gz", hash = "sha256:90215863b56e212086641956b20127ccbf6d8a3a38343dad01d6a74d19482f76"},
+    {file = "jsonschema_spec-0.2.2-py3-none-any.whl", hash = "sha256:8a4be06134787e4d747dfb68851b9f9bceafcaa90647a852e8e8993af11705e2"},
+    {file = "jsonschema_spec-0.2.2.tar.gz", hash = "sha256:a5c98c2b0be73a1b3cf8464b8a300210d1006eb086ffb9fb0e58b19052ec86ec"},
 ]
 
 [package.dependencies]
-jsonschema = ">=4.0.0,<4.18.0"
 pathable = ">=0.4.1,<0.5.0"
 PyYAML = ">=5.1"
+referencing = ">=0.28.0,<0.30.0"
 requests = ">=2.31.0,<3.0.0"
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2023.5.2"
+description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jsonschema_specifications-2023.5.2-py3-none-any.whl", hash = "sha256:51d2972bf690cfe21970f722f878580d863f7c127d200fce671c5dae10b88f5f"},
+    {file = "jsonschema_specifications-2023.5.2.tar.gz", hash = "sha256:1aefc07b022e3b8ce8bec135c78b74ae1ffd260822c67011427192b3a7525e09"},
+]
+
+[package.dependencies]
+importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
+referencing = ">=0.28.0"
 
 [[package]]
 name = "lazy-object-proxy"
@@ -1316,39 +1333,37 @@ setuptools = "*"
 
 [[package]]
 name = "openapi-schema-validator"
-version = "0.4.4"
+version = "0.6.0a1"
 description = "OpenAPI schema validation for Python"
 optional = false
-python-versions = ">=3.7.0,<4.0.0"
+python-versions = ">=3.8.0,<4.0.0"
 files = [
-    {file = "openapi_schema_validator-0.4.4-py3-none-any.whl", hash = "sha256:79f37f38ef9fd5206b924ed7a6f382cea7b649b3b56383c47f1906082b7b9015"},
-    {file = "openapi_schema_validator-0.4.4.tar.gz", hash = "sha256:c573e2be2c783abae56c5a1486ab716ca96e09d1c3eab56020d1dc680aa57bf8"},
+    {file = "openapi_schema_validator-0.6.0a1-py3-none-any.whl", hash = "sha256:ba58308d97f7382c84d9462788530fb45b928f8c5afbf0d66f7e9a38ae19505c"},
+    {file = "openapi_schema_validator-0.6.0a1.tar.gz", hash = "sha256:e6edc71d4d7d7c57649a32613657033243d7ff326b787a00aa69151b4ee10d35"},
 ]
 
 [package.dependencies]
-jsonschema = ">=4.0.0,<4.18.0"
+jsonschema = ">=4.18.0a1,<5.0.0"
+jsonschema-specifications = ">=2023.5.2,<2024.0.0"
 rfc3339-validator = "*"
-
-[package.extras]
-docs = ["sphinx (>=5.3.0,<6.0.0)", "sphinx-immaterial (>=0.11.0,<0.12.0)"]
 
 [[package]]
 name = "openapi-spec-validator"
-version = "0.5.7"
+version = "0.6.0a2"
 description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3 spec validator"
 optional = false
-python-versions = ">=3.7.0,<4.0.0"
+python-versions = ">=3.8.0,<4.0.0"
 files = [
-    {file = "openapi_spec_validator-0.5.7-py3-none-any.whl", hash = "sha256:8712d2879db7692974ef89c47a3ebfc79436442921ec3a826ac0ce80cde8c549"},
-    {file = "openapi_spec_validator-0.5.7.tar.gz", hash = "sha256:6c2d42180045a80fd6314de848b94310bdb0fa4949f4b099578b69f79d9fa5ac"},
+    {file = "openapi_spec_validator-0.6.0a2-py3-none-any.whl", hash = "sha256:b8c6d8d8da171e355c2fab84f12637e3cfa4d405447ea62dc861c27d4cbc1dd5"},
+    {file = "openapi_spec_validator-0.6.0a2.tar.gz", hash = "sha256:7092c1824cf87b5aff20f7bf8be2a78b3edcee01144e99980e4f7bc82d20ed35"},
 ]
 
 [package.dependencies]
 importlib-resources = {version = ">=5.8.0,<6.0.0", markers = "python_version < \"3.9\""}
-jsonschema = ">=4.0.0,<4.18.0"
-jsonschema-spec = ">=0.1.1,<0.2.0"
+jsonschema = ">=4.18.0a1,<5.0.0"
+jsonschema-spec = ">=0.2.2,<0.3.0"
 lazy-object-proxy = ">=1.7.1,<2.0.0"
-openapi-schema-validator = ">=0.4.2,<0.5.0"
+openapi-schema-validator = ">=0.6.0a1,<0.7.0"
 
 [[package]]
 name = "packaging"
@@ -1541,42 +1556,6 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
-name = "pyrsistent"
-version = "0.19.3"
-description = "Persistent/Functional/Immutable data structures"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a"},
-    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64"},
-    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf"},
-    {file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a"},
-    {file = "pyrsistent-0.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:49c32f216c17148695ca0e02a5c521e28a4ee6c5089f97e34fe24163113722da"},
-    {file = "pyrsistent-0.19.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0774bf48631f3a20471dd7c5989657b639fd2d285b861237ea9e82c36a415a9"},
-    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab2204234c0ecd8b9368dbd6a53e83c3d4f3cab10ecaf6d0e772f456c442393"},
-    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e42296a09e83028b3476f7073fcb69ffebac0e66dbbfd1bd847d61f74db30f19"},
-    {file = "pyrsistent-0.19.3-cp311-cp311-win32.whl", hash = "sha256:64220c429e42a7150f4bfd280f6f4bb2850f95956bde93c6fda1b70507af6ef3"},
-    {file = "pyrsistent-0.19.3-cp311-cp311-win_amd64.whl", hash = "sha256:016ad1afadf318eb7911baa24b049909f7f3bb2c5b1ed7b6a8f21db21ea3faa8"},
-    {file = "pyrsistent-0.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4db1bd596fefd66b296a3d5d943c94f4fac5bcd13e99bffe2ba6a759d959a28"},
-    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aeda827381f5e5d65cced3024126529ddc4289d944f75e090572c77ceb19adbf"},
-    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42ac0b2f44607eb92ae88609eda931a4f0dfa03038c44c772e07f43e738bcac9"},
-    {file = "pyrsistent-0.19.3-cp37-cp37m-win32.whl", hash = "sha256:e8f2b814a3dc6225964fa03d8582c6e0b6650d68a232df41e3cc1b66a5d2f8d1"},
-    {file = "pyrsistent-0.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c9bb60a40a0ab9aba40a59f68214eed5a29c6274c83b2cc206a359c4a89fa41b"},
-    {file = "pyrsistent-0.19.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a2471f3f8693101975b1ff85ffd19bb7ca7dd7c38f8a81701f67d6b4f97b87d8"},
-    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc5d149f31706762c1f8bda2e8c4f8fead6e80312e3692619a75301d3dbb819a"},
-    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3311cb4237a341aa52ab8448c27e3a9931e2ee09561ad150ba94e4cfd3fc888c"},
-    {file = "pyrsistent-0.19.3-cp38-cp38-win32.whl", hash = "sha256:f0e7c4b2f77593871e918be000b96c8107da48444d57005b6a6bc61fb4331b2c"},
-    {file = "pyrsistent-0.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:c147257a92374fde8498491f53ffa8f4822cd70c0d85037e09028e478cababb7"},
-    {file = "pyrsistent-0.19.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b735e538f74ec31378f5a1e3886a26d2ca6351106b4dfde376a26fc32a044edc"},
-    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99abb85579e2165bd8522f0c0138864da97847875ecbd45f3e7e2af569bfc6f2"},
-    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a8cb235fa6d3fd7aae6a4f1429bbb1fec1577d978098da1252f0489937786f3"},
-    {file = "pyrsistent-0.19.3-cp39-cp39-win32.whl", hash = "sha256:c74bed51f9b41c48366a286395c67f4e894374306b197e62810e0fdaf2364da2"},
-    {file = "pyrsistent-0.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:878433581fc23e906d947a6814336eee031a00e6defba224234169ae3d3d6a98"},
-    {file = "pyrsistent-0.19.3-py3-none-any.whl", hash = "sha256:ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64"},
-    {file = "pyrsistent-0.19.3.tar.gz", hash = "sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440"},
-]
-
-[[package]]
 name = "pytest"
 version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
@@ -1729,6 +1708,21 @@ files = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.29.0"
+description = "JSON Referencing + Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "referencing-0.29.0-py3-none-any.whl", hash = "sha256:bddd26f8fbb64d153334cca7bc20305c72295e287d84bbf5756afa50efdeb6ae"},
+    {file = "referencing-0.29.0.tar.gz", hash = "sha256:54b64ae36b91827f9f50d05a5af27570a5ca9ba6a1be49809215419d5ab32253"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+rpds-py = ">=0.7.0"
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -1782,6 +1776,38 @@ files = [
 
 [package.dependencies]
 six = "*"
+
+[[package]]
+name = "rpds-py"
+version = "0.7.1"
+description = "Python bindings to Rust's persistent data structures (rpds)"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "rpds_py-0.7.1-cp38-abi3-macosx_10_7_x86_64.whl", hash = "sha256:858604fe5d7eb50e91b1096bcbcb421f2cb3101454244afda92b4d768d0cb4ce"},
+    {file = "rpds_py-0.7.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:e16c02923726307d960e908b61d4d833939f322877d2957c001fca23b644914e"},
+    {file = "rpds_py-0.7.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:311a57cc972481bd220af28cf4309141c680a356b2359f163daac030d0c2318d"},
+    {file = "rpds_py-0.7.1-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b6db70c2ab847229fa9cff3a5eb641c33ab3f981ee8b99d326a7deb8989e4ce"},
+    {file = "rpds_py-0.7.1-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:34007442d36980c4aab3f4044c1fd05a736c8ae09d47b8a42112deab5d6b5a10"},
+    {file = "rpds_py-0.7.1-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d1d4078d60ca47f0eb6bdddbf79f00a72d41ee3148aba1dcf9b980f73a8d26e"},
+    {file = "rpds_py-0.7.1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:025b8101dbf39d77cf41ac3c737e4c713e0b2728a516443b382e66b9d492ff98"},
+    {file = "rpds_py-0.7.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cc6ff891c3814d8cd92549cb385353a922518d433aaf1d2d0d99e98e59915370"},
+    {file = "rpds_py-0.7.1-cp38-abi3-win32.whl", hash = "sha256:cbdc8ab6108b8bb260ee68fb2de83fb1c481d3a77355156049a8a49ea47eacf6"},
+    {file = "rpds_py-0.7.1-cp38-abi3-win_amd64.whl", hash = "sha256:5eda3aba0cd291de9d4bb138db45814bac24bc4c07e0f38b0544374b6104c488"},
+    {file = "rpds_py-0.7.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:038249d2bbaf91aa65c4108a40ee076f657654261b1a246ab99726710bfb77de"},
+    {file = "rpds_py-0.7.1-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2a5c672b1cd382973bf414518ddc9d743d06bcee751fa65256d84ba412192b0b"},
+    {file = "rpds_py-0.7.1-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:453e62d679d8de32c5e00ba27f8c8c45a456e5d6db6fa6f67fdd3e12f1658833"},
+    {file = "rpds_py-0.7.1-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0bcb162f5549408125ec986bfed1a66f2036ac2910d3fb0a6afda0f97bc6ea15"},
+    {file = "rpds_py-0.7.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98b54a47e670093b8bf7d1a0222d0af26dac19314a0e79ac478e447357396a2d"},
+    {file = "rpds_py-0.7.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f53f65cf56bb60355681431d04bc04dbe709452dd85eebf537035dc145bd36c9"},
+    {file = "rpds_py-0.7.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68e8f2cedc65198248a14d716125016fd0816f63f216a82c2209a0686d5447cf"},
+    {file = "rpds_py-0.7.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8391420714e84ae9f4c6d4e4d52eb4209ca8d66abfbe4b2ba4892221be1c6f5"},
+    {file = "rpds_py-0.7.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c7bd3a381c4a5fe7e0fc4dff554bd1ce2b0be12ba0193c176c291b7dc1e8bea0"},
+    {file = "rpds_py-0.7.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c38d17af73aa03686d701686628e37c114a459650233c0d5f0492dad3a76e3e0"},
+    {file = "rpds_py-0.7.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:014828cd68b4cdee84ab66adaf5bfe1f137656a7a588c31fdca04ba0768ef62d"},
+    {file = "rpds_py-0.7.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:33a2a15b641bc17bc6574f9600976374a085ff81ac8dddd4bde6c451e9e9e58d"},
+    {file = "rpds_py-0.7.1.tar.gz", hash = "sha256:d940b5644f14e49b1c6e7902b9ec8a0c7584109fbf380fa18115831a641927c8"},
+]
 
 [[package]]
 name = "setuptools"
@@ -2252,4 +2278,4 @@ starlette = ["starlette"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "c51c620fb60a2b350330613a76daad2d10a7892c9cb0eb3fd31e886a3634d394"
+content-hash = "f959eda0ef4723b8752d707f50b0ce9ffaf6645cb79d52cf38dbca490f64e9e7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,13 +67,13 @@ starlette = {version = ">=0.26.1,<0.29.0", optional = true}
 isodate = "*"
 more-itertools = "*"
 parse = "*"
-openapi-schema-validator = "^0.4.2"
-openapi-spec-validator = "^0.5.0"
+openapi-schema-validator = {version = "^0.6.0a1", allow-prereleases = true}
+openapi-spec-validator = {version = "^0.6.0a2", allow-prereleases = true}
 requests = {version = "*", optional = true}
 werkzeug = "*"
-jsonschema-spec = "^0.1.6"
+jsonschema-spec = "^0.2.2"
 asgiref = "^3.6.0"
-jsonschema = "^4.17.3"
+jsonschema = {version = "^4.18.0a1", allow-prereleases = true}
 multidict = {version = "^6.0.4", optional = true}
 lazy-object-proxy = "^1.7.1"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,14 +15,14 @@ def content_from_file(spec_file):
 
 
 def spec_from_file(spec_file):
-    spec_dict, spec_url = content_from_file(spec_file)
-    return Spec.from_dict(spec_dict, spec_url=spec_url)
+    spec_dict, base_uri = content_from_file(spec_file)
+    return Spec.from_dict(spec_dict, base_uri=base_uri)
 
 
-def spec_from_url(spec_url):
-    content = request.urlopen(spec_url)
+def spec_from_url(base_uri):
+    content = request.urlopen(base_uri)
     spec_dict = safe_load(content)
-    return Spec.from_dict(spec_dict, spec_url=spec_url)
+    return Spec.from_dict(spec_dict, base_uri=base_uri)
 
 
 class Factory(dict):
@@ -47,5 +47,5 @@ def v30_petstore_content(factory):
 
 @pytest.fixture(scope="session")
 def v30_petstore_spec(v30_petstore_content):
-    spec_url = "file://tests/integration/data/v3.0/petstore.yaml"
-    return Spec.from_dict(v30_petstore_content, spec_url=spec_url)
+    base_uri = "file://tests/integration/data/v3.0/petstore.yaml"
+    return Spec.from_dict(v30_petstore_content, base_uri=base_uri)

--- a/tests/integration/schema/test_spec.py
+++ b/tests/integration/schema/test_spec.py
@@ -21,7 +21,7 @@ class TestPetstore:
         return str(api_key_bytes_enc, "utf8")
 
     @pytest.fixture
-    def spec_uri(self):
+    def base_uri(self):
         return "file://tests/integration/data/v3.0/petstore.yaml"
 
     @pytest.fixture
@@ -30,9 +30,9 @@ class TestPetstore:
         return content
 
     @pytest.fixture
-    def spec(self, spec_dict, spec_uri):
+    def spec(self, spec_dict, base_uri):
         return Spec.from_dict(
-            spec_dict, spec_url=spec_uri, validator=openapi_v30_spec_validator
+            spec_dict, base_uri=base_uri, validator=openapi_v30_spec_validator
         )
 
     @pytest.fixture
@@ -312,7 +312,7 @@ class TestWebhook:
         return str(api_key_bytes_enc, "utf8")
 
     @pytest.fixture
-    def spec_uri(self):
+    def base_uri(self):
         return "file://tests/integration/data/v3.1/webhook-example.yaml"
 
     @pytest.fixture
@@ -323,10 +323,10 @@ class TestWebhook:
         return content
 
     @pytest.fixture
-    def spec(self, spec_dict, spec_uri):
+    def spec(self, spec_dict, base_uri):
         return Spec.from_dict(
             spec_dict,
-            spec_url=spec_uri,
+            base_uri=base_uri,
             validator=openapi_v31_spec_validator,
         )
 

--- a/tests/integration/unmarshalling/test_unmarshallers.py
+++ b/tests/integration/unmarshalling/test_unmarshallers.py
@@ -265,8 +265,6 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
     @pytest.mark.parametrize(
         "type,format,value",
         [
-            ("number", "float", 3),
-            ("number", "double", 3),
             ("string", "date", "test"),
             ("string", "date-time", "test"),
             ("string", "uuid", "test"),


### PR DESCRIPTION
Support for jsonschema 4.18, jsonschema-spec 0.2, openapi-schema-validator 0.6 and openapi-spec-validator 0.6

* `spec_url` parameter of `Spec.from_dict` is deprecated. Use `base_uri` instead.
* `ref_resolver_handlers` parameter of `Spec.from_dict` is deprecated. Use `handlers` instead.