### PR TITLE
Skip response validation option

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -63,6 +63,22 @@ Django can be integrated by middleware. Add ``DjangoOpenAPIMiddleware`` to your 
 
     OPENAPI_SPEC = Spec.from_dict(spec_dict)
 
+You can skip response validation process: by setting ``OPENAPI_RESPONSE_CLS`` to ``None``
+
+.. code-block:: python
+  :emphasize-lines: 10
+
+    # settings.py
+    from openapi_core import Spec
+
+    MIDDLEWARE = [
+       # ...
+       'openapi_core.contrib.django.middlewares.DjangoOpenAPIMiddleware',
+    ]
+
+    OPENAPI_SPEC = Spec.from_dict(spec_dict)
+    OPENAPI_RESPONSE_CLS = None
+
 After that you have access to unmarshal result object with all validated request data from Django view through request object.
 
 .. code-block:: python
@@ -146,6 +162,23 @@ Additional customization parameters can be passed to the middleware.
        middleware=[openapi_middleware],
     )
 
+You can skip response validation process: by setting ``response_cls`` to ``None``
+
+.. code-block:: python
+  :emphasize-lines: 5
+
+    from openapi_core.contrib.falcon.middlewares import FalconOpenAPIMiddleware
+
+    openapi_middleware = FalconOpenAPIMiddleware.from_spec(
+       spec,
+       response_cls=None,
+    )
+
+    app = falcon.App(
+       # ...
+       middleware=[openapi_middleware],
+    )
+
 After that you will have access to validation result object with all validated request data from Falcon view through request context.
 
 .. code-block:: python
@@ -219,6 +252,18 @@ Additional customization parameters can be passed to the decorator.
     openapi = FlaskOpenAPIViewDecorator.from_spec(
        spec,
        extra_format_validators=extra_format_validators,
+    )
+
+You can skip response validation process: by setting ``response_cls`` to ``None``
+
+.. code-block:: python
+  :emphasize-lines: 5
+
+    from openapi_core.contrib.flask.decorators import FlaskOpenAPIViewDecorator
+
+    openapi = FlaskOpenAPIViewDecorator.from_spec(
+       spec,
+       response_cls=None,
     )
 
 If you want to decorate class based view you can use the decorators attribute:

--- a/openapi_core/contrib/falcon/middlewares.py
+++ b/openapi_core/contrib/falcon/middlewares.py
@@ -20,8 +20,8 @@ from openapi_core.unmarshalling.response.types import ResponseUnmarshallerType
 
 
 class FalconOpenAPIMiddleware(UnmarshallingProcessor):
-    request_class = FalconOpenAPIRequest
-    response_class = FalconOpenAPIResponse
+    request_cls = FalconOpenAPIRequest
+    response_cls = FalconOpenAPIResponse
     errors_handler = FalconOpenAPIErrorsHandler()
 
     def __init__(
@@ -29,8 +29,8 @@ class FalconOpenAPIMiddleware(UnmarshallingProcessor):
         spec: Spec,
         request_unmarshaller_cls: Optional[RequestUnmarshallerType] = None,
         response_unmarshaller_cls: Optional[ResponseUnmarshallerType] = None,
-        request_class: Type[FalconOpenAPIRequest] = FalconOpenAPIRequest,
-        response_class: Type[FalconOpenAPIResponse] = FalconOpenAPIResponse,
+        request_cls: Type[FalconOpenAPIRequest] = FalconOpenAPIRequest,
+        response_cls: Type[FalconOpenAPIResponse] = FalconOpenAPIResponse,
         errors_handler: Optional[FalconOpenAPIErrorsHandler] = None,
         **unmarshaller_kwargs: Any,
     ):
@@ -40,8 +40,8 @@ class FalconOpenAPIMiddleware(UnmarshallingProcessor):
             response_unmarshaller_cls=response_unmarshaller_cls,
             **unmarshaller_kwargs,
         )
-        self.request_class = request_class or self.request_class
-        self.response_class = response_class or self.response_class
+        self.request_cls = request_cls or self.request_cls
+        self.response_cls = response_cls or self.response_cls
         self.errors_handler = errors_handler or self.errors_handler
 
     @classmethod
@@ -50,8 +50,8 @@ class FalconOpenAPIMiddleware(UnmarshallingProcessor):
         spec: Spec,
         request_unmarshaller_cls: Optional[RequestUnmarshallerType] = None,
         response_unmarshaller_cls: Optional[ResponseUnmarshallerType] = None,
-        request_class: Type[FalconOpenAPIRequest] = FalconOpenAPIRequest,
-        response_class: Type[FalconOpenAPIResponse] = FalconOpenAPIResponse,
+        request_cls: Type[FalconOpenAPIRequest] = FalconOpenAPIRequest,
+        response_cls: Type[FalconOpenAPIResponse] = FalconOpenAPIResponse,
         errors_handler: Optional[FalconOpenAPIErrorsHandler] = None,
         **unmarshaller_kwargs: Any,
     ) -> "FalconOpenAPIMiddleware":
@@ -59,8 +59,8 @@ class FalconOpenAPIMiddleware(UnmarshallingProcessor):
             spec,
             request_unmarshaller_cls=request_unmarshaller_cls,
             response_unmarshaller_cls=response_unmarshaller_cls,
-            request_class=request_class,
-            response_class=response_class,
+            request_cls=request_cls,
+            response_cls=response_cls,
             errors_handler=errors_handler,
             **unmarshaller_kwargs,
         )
@@ -74,6 +74,8 @@ class FalconOpenAPIMiddleware(UnmarshallingProcessor):
     def process_response(  # type: ignore
         self, req: Request, resp: Response, resource: Any, req_succeeded: bool
     ) -> None:
+        if self.response_cls is None:
+            return resp
         openapi_req = self._get_openapi_request(req)
         openapi_resp = self._get_openapi_response(resp)
         resp.context.openapi = super().process_response(
@@ -101,9 +103,10 @@ class FalconOpenAPIMiddleware(UnmarshallingProcessor):
         return self.errors_handler.handle(req, resp, response_result.errors)
 
     def _get_openapi_request(self, request: Request) -> FalconOpenAPIRequest:
-        return self.request_class(request)
+        return self.request_cls(request)
 
     def _get_openapi_response(
         self, response: Response
     ) -> FalconOpenAPIResponse:
-        return self.response_class(response)
+        assert self.response_cls is not None
+        return self.response_cls(response)

--- a/openapi_core/contrib/flask/__init__.py
+++ b/openapi_core/contrib/flask/__init__.py
@@ -1,7 +1,9 @@
+from openapi_core.contrib.flask.decorators import FlaskOpenAPIViewDecorator
 from openapi_core.contrib.flask.requests import FlaskOpenAPIRequest
 from openapi_core.contrib.flask.responses import FlaskOpenAPIResponse
 
 __all__ = [
+    "FlaskOpenAPIViewDecorator",
     "FlaskOpenAPIRequest",
     "FlaskOpenAPIResponse",
 ]

--- a/openapi_core/contrib/flask/decorators.py
+++ b/openapi_core/contrib/flask/decorators.py
@@ -30,8 +30,10 @@ class FlaskOpenAPIViewDecorator(UnmarshallingProcessor):
         spec: Spec,
         request_unmarshaller_cls: Optional[RequestUnmarshallerType] = None,
         response_unmarshaller_cls: Optional[ResponseUnmarshallerType] = None,
-        request_class: Type[FlaskOpenAPIRequest] = FlaskOpenAPIRequest,
-        response_class: Type[FlaskOpenAPIResponse] = FlaskOpenAPIResponse,
+        request_cls: Type[FlaskOpenAPIRequest] = FlaskOpenAPIRequest,
+        response_cls: Optional[
+            Type[FlaskOpenAPIResponse]
+        ] = FlaskOpenAPIResponse,
         request_provider: Type[FlaskRequestProvider] = FlaskRequestProvider,
         openapi_errors_handler: Type[
             FlaskOpenAPIErrorsHandler
@@ -44,8 +46,8 @@ class FlaskOpenAPIViewDecorator(UnmarshallingProcessor):
             response_unmarshaller_cls=response_unmarshaller_cls,
             **unmarshaller_kwargs,
         )
-        self.request_class = request_class
-        self.response_class = response_class
+        self.request_cls = request_cls
+        self.response_cls = response_cls
         self.request_provider = request_provider
         self.openapi_errors_handler = openapi_errors_handler
 
@@ -60,6 +62,8 @@ class FlaskOpenAPIViewDecorator(UnmarshallingProcessor):
             response = self._handle_request_view(
                 request_result, view, *args, **kwargs
             )
+            if self.response_cls is None:
+                return response
             openapi_response = self._get_openapi_response(response)
             response_result = self.process_response(
                 openapi_request, openapi_response
@@ -96,12 +100,13 @@ class FlaskOpenAPIViewDecorator(UnmarshallingProcessor):
         return request
 
     def _get_openapi_request(self, request: Request) -> FlaskOpenAPIRequest:
-        return self.request_class(request)
+        return self.request_cls(request)
 
     def _get_openapi_response(
         self, response: Response
     ) -> FlaskOpenAPIResponse:
-        return self.response_class(response)
+        assert self.response_cls is not None
+        return self.response_cls(response)
 
     @classmethod
     def from_spec(
@@ -109,8 +114,8 @@ class FlaskOpenAPIViewDecorator(UnmarshallingProcessor):
         spec: Spec,
         request_unmarshaller_cls: Optional[RequestUnmarshallerType] = None,
         response_unmarshaller_cls: Optional[ResponseUnmarshallerType] = None,
-        request_class: Type[FlaskOpenAPIRequest] = FlaskOpenAPIRequest,
-        response_class: Type[FlaskOpenAPIResponse] = FlaskOpenAPIResponse,
+        request_cls: Type[FlaskOpenAPIRequest] = FlaskOpenAPIRequest,
+        response_cls: Type[FlaskOpenAPIResponse] = FlaskOpenAPIResponse,
         request_provider: Type[FlaskRequestProvider] = FlaskRequestProvider,
         openapi_errors_handler: Type[
             FlaskOpenAPIErrorsHandler
@@ -121,8 +126,8 @@ class FlaskOpenAPIViewDecorator(UnmarshallingProcessor):
             spec,
             request_unmarshaller_cls=request_unmarshaller_cls,
             response_unmarshaller_cls=response_unmarshaller_cls,
-            request_class=request_class,
-            response_class=response_class,
+            request_cls=request_cls,
+            response_cls=response_cls,
             request_provider=request_provider,
             openapi_errors_handler=openapi_errors_handler,
             **unmarshaller_kwargs,

--- a/tests/integration/contrib/django/data/v3.0/djangoproject/tags/views.py
+++ b/tests/integration/contrib/django/data/v3.0/djangoproject/tags/views.py
@@ -1,0 +1,13 @@
+from django.http import HttpResponse
+from rest_framework.views import APIView
+
+
+class TagListView(APIView):
+    def get(self, request):
+        assert request.openapi
+        assert not request.openapi.errors
+        return HttpResponse("success")
+
+    @staticmethod
+    def get_extra_actions():
+        return []

--- a/tests/integration/contrib/django/data/v3.0/djangoproject/urls.py
+++ b/tests/integration/contrib/django/data/v3.0/djangoproject/urls.py
@@ -16,7 +16,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include
 from django.urls import path
-from djangoproject.pets import views
+from djangoproject.pets.views import PetDetailView
+from djangoproject.pets.views import PetListView
+from djangoproject.tags.views import TagListView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -26,12 +28,17 @@ urlpatterns = [
     ),
     path(
         "v1/pets",
-        views.PetListView.as_view(),
+        PetListView.as_view(),
         name="pet_list_view",
     ),
     path(
         "v1/pets/<int:petId>",
-        views.PetDetailView.as_view(),
+        PetDetailView.as_view(),
         name="pet_detail_view",
+    ),
+    path(
+        "v1/tags",
+        TagListView.as_view(),
+        name="tag_list_view",
     ),
 ]

--- a/tests/integration/contrib/django/test_django_project.py
+++ b/tests/integration/contrib/django/test_django_project.py
@@ -5,6 +5,7 @@ from json import dumps
 from unittest import mock
 
 import pytest
+from django.test.utils import override_settings
 
 
 class BaseTestDjangoProject:
@@ -372,3 +373,25 @@ class TestDRFPetListView(BaseTestDRF):
 
         assert response.status_code == 201
         assert not response.content
+
+
+class TestDRFTagListView(BaseTestDRF):
+    def test_get_response_invalid(self, client):
+        headers = {
+            "HTTP_AUTHORIZATION": "Basic testuser",
+            "HTTP_HOST": "petstore.swagger.io",
+        }
+        response = client.get("/v1/tags", **headers)
+
+        assert response.status_code == 415
+
+    def test_get_skip_response_validation(self, client):
+        headers = {
+            "HTTP_AUTHORIZATION": "Basic testuser",
+            "HTTP_HOST": "petstore.swagger.io",
+        }
+        with override_settings(OPENAPI_RESPONSE_CLS=None):
+            response = client.get("/v1/tags", **headers)
+
+        assert response.status_code == 200
+        assert response.content == b"success"

--- a/tests/integration/contrib/flask/conftest.py
+++ b/tests/integration/contrib/flask/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+from flask import Flask
+
+
+@pytest.fixture(scope="session")
+def spec(factory):
+    specfile = "contrib/flask/data/v3.0/flask_factory.yaml"
+    return factory.spec_from_file(specfile)
+
+
+@pytest.fixture
+def app(app_factory):
+    return app_factory()
+
+
+@pytest.fixture
+def client(client_factory, app):
+    return client_factory(app)
+
+
+@pytest.fixture(scope="session")
+def client_factory():
+    def create(app):
+        return app.test_client()
+
+    return create
+
+
+@pytest.fixture(scope="session")
+def app_factory():
+    def create(root_path=None):
+        app = Flask("__main__", root_path=root_path)
+        app.config["DEBUG"] = True
+        app.config["TESTING"] = True
+        return app
+
+    return create

--- a/tests/integration/contrib/flask/data/v3.0/flask_factory.yaml
+++ b/tests/integration/contrib/flask/data/v3.0/flask_factory.yaml
@@ -13,6 +13,12 @@ paths:
         description: the ID of the resource to retrieve
         schema:
           type: integer
+      - name: q
+        in: query
+        required: false
+        description: query key
+        schema:
+          type: string
     get:
       responses:
         404:
@@ -25,6 +31,57 @@ paths:
           description: Return the resource.
           content:
             application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: string
+          headers:
+            X-Rate-Limit:
+              description: Rate limit
+              schema:
+                type: integer
+              required: true
+        default:
+          description: Return errors.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - errors
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                        code:
+                          type: string
+                        message:
+                          type: string
+    post:
+      requestBody:
+        description: request data
+        required: True
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - param1
+              properties:
+                param1:
+                  type: integer
+      responses:
+        200:
+          description: Return the resource.
+          content:
+            application/json:    
               schema:
                 type: object
                 required:

--- a/tests/integration/contrib/flask/test_flask_validator.py
+++ b/tests/integration/contrib/flask/test_flask_validator.py
@@ -9,22 +9,9 @@ from openapi_core import V30RequestUnmarshaller
 from openapi_core.contrib.flask import FlaskOpenAPIRequest
 
 
-class TestWerkzeugOpenAPIValidation:
-    @pytest.fixture
-    def spec(self, factory):
-        specfile = "contrib/requests/data/v3.0/requests_factory.yaml"
-        return factory.spec_from_file(specfile)
-
-    @pytest.fixture
-    def app(self):
-        app = Flask("__main__", root_path="/browse")
-        app.config["DEBUG"] = True
-        app.config["TESTING"] = True
-        return app
-
-    @pytest.fixture
-    def details_view_func(self, spec):
-        def datails_browse(id):
+class TestFlaskOpenAPIValidation:
+    def test_request_validator_root_path(self, spec, app_factory):
+        def details_view_func(id):
             from flask import request
 
             openapi_request = FlaskOpenAPIRequest(request)
@@ -42,26 +29,18 @@ class TestWerkzeugOpenAPIValidation:
             else:
                 return Response("Not Found", status=404)
 
-        return datails_browse
-
-    @pytest.fixture(autouse=True)
-    def view(self, app, details_view_func):
+        app = app_factory(root_path="/browse")
         app.add_url_rule(
             "/<id>/",
             view_func=details_view_func,
             methods=["POST"],
         )
-
-    @pytest.fixture
-    def client(self, app):
-        return FlaskClient(app)
-
-    def test_request_validator_root_path(self, client):
         query_string = {
             "q": "string",
         }
         headers = {"content-type": "application/json"}
         data = {"param1": 1}
+        client = FlaskClient(app)
         result = client.post(
             "/12/",
             base_url="http://localhost/browse",


### PR DESCRIPTION
`response_cls` (`OPENAPI_RESPONSE_CLS` in Django) set to `None` skips response validation.

Fixes #662