### PR TITLE
HTTP content-type isn't using charset

### DIFF
--- a/openapi_core/unmarshalling/response/unmarshallers.py
+++ b/openapi_core/unmarshalling/response/unmarshallers.py
@@ -63,9 +63,12 @@ class BaseResponseUnmarshaller(BaseResponseValidator, BaseUnmarshaller):
         except ResponseFinderError as exc:
             return ResponseUnmarshalResult(errors=[exc])
 
+        # Drop optional "; charset=utf-8"
+        mimetype = response.mimetype.split(';')[0]
+
         try:
             validated_data = self._get_data(
-                response.data, response.mimetype, operation_response
+                response.data, mimetype, operation_response
             )
         except DataValidationError as exc:
             validated_data = None
@@ -103,9 +106,12 @@ class BaseResponseUnmarshaller(BaseResponseValidator, BaseUnmarshaller):
         except ResponseFinderError as exc:
             return ResponseUnmarshalResult(errors=[exc])
 
+        # Drop optional "; charset=utf-8"
+        mimetype = response.mimetype.split(';')[0]
+
         try:
             validated = self._get_data(
-                response.data, response.mimetype, operation_response
+                response.data, mimetype, operation_response
             )
         except DataValidationError as exc:
             validated = None


### PR DESCRIPTION
On a typical API-schema, content types don't have charsets. For example _application/json_ charset is assumed to be UTF-8 by RFC 8259. For example _text/xml_, there is relevance. In neither case API-schema doesn't specify multiple contents for different charsets. 

Thus, not using HTTP-response charset for API-schema verification doesn't make sense. For those response verifications with assumed charset, there is no need to fail. For those responses which are in varying charsets, verifying data is impossible as there is no decoding the response data into Unicode used by Python internally. Again, charset doesn't have any relevance and can be ignored.

Ref.: [https://datatracker.ietf.org/doc/html/rfc2046#section-4.1.2](https://datatracker.ietf.org/doc/html/rfc2046#section-4.1.2)
Ref.: [https://datatracker.ietf.org/doc/html/rfc8259#section-8.1](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)