### PR TITLE
Replace mimetype with content_type

### DIFF
--- a/openapi_core/contrib/aiohttp/requests.py
+++ b/openapi_core/contrib/aiohttp/requests.py
@@ -49,5 +49,5 @@ class AIOHTTPOpenAPIWebRequest:
         return self._body
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         return self.request.content_type

--- a/openapi_core/contrib/aiohttp/responses.py
+++ b/openapi_core/contrib/aiohttp/responses.py
@@ -26,7 +26,7 @@ class AIOHTTPOpenAPIWebResponse:
         return self.response.status
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         return self.response.content_type or ""
 
     @property

--- a/openapi_core/contrib/django/requests.py
+++ b/openapi_core/contrib/django/requests.py
@@ -81,5 +81,7 @@ class DjangoOpenAPIRequest:
         return self.request.body.decode("utf-8")
 
     @property
-    def mimetype(self) -> str:
-        return self.request.content_type or ""
+    def content_type(self) -> str:
+        content_type = self.request.META.get("CONTENT_TYPE", "")
+        assert isinstance(content_type, str)
+        return content_type

--- a/openapi_core/contrib/django/responses.py
+++ b/openapi_core/contrib/django/responses.py
@@ -26,7 +26,7 @@ class DjangoOpenAPIResponse:
         return Headers(self.response.headers.items())
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         content_type = self.response.get("Content-Type", "")
         assert isinstance(content_type, str)
         return content_type

--- a/openapi_core/contrib/falcon/requests.py
+++ b/openapi_core/contrib/falcon/requests.py
@@ -56,10 +56,10 @@ class FalconOpenAPIRequest:
         return dumps(getattr(self.request, "json", media))
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         if self.request.content_type:
             assert isinstance(self.request.content_type, str)
-            return self.request.content_type.partition(";")[0]
+            return self.request.content_type
 
         assert isinstance(self.request.options, RequestOptions)
         assert isinstance(self.request.options.default_media_type, str)

--- a/openapi_core/contrib/falcon/responses.py
+++ b/openapi_core/contrib/falcon/responses.py
@@ -21,13 +21,13 @@ class FalconOpenAPIResponse:
         return int(self.response.status[:3])
 
     @property
-    def mimetype(self) -> str:
-        mimetype = ""
+    def content_type(self) -> str:
+        content_type = ""
         if self.response.content_type:
-            mimetype = self.response.content_type.partition(";")[0]
+            content_type = self.response.content_type
         else:
-            mimetype = self.response.options.default_media_type
-        return mimetype
+            content_type = self.response.options.default_media_type
+        return content_type
 
     @property
     def headers(self) -> Headers:

--- a/openapi_core/contrib/requests/requests.py
+++ b/openapi_core/contrib/requests/requests.py
@@ -74,13 +74,13 @@ class RequestsOpenAPIRequest:
         return self.request.body
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         # Order matters because all python requests issued from a session
         # include Accept */* which does not necessarily match the content type
         return str(
             self.request.headers.get("Content-Type")
             or self.request.headers.get("Accept")
-        ).split(";")[0]
+        )
 
 
 class RequestsOpenAPIWebhookRequest(RequestsOpenAPIRequest):

--- a/openapi_core/contrib/requests/responses.py
+++ b/openapi_core/contrib/requests/responses.py
@@ -19,7 +19,7 @@ class RequestsOpenAPIResponse:
         return int(self.response.status_code)
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         return str(self.response.headers.get("Content-Type", ""))
 
     @property

--- a/openapi_core/contrib/starlette/requests.py
+++ b/openapi_core/contrib/starlette/requests.py
@@ -44,9 +44,9 @@ class StarletteOpenAPIRequest:
         return body
 
     @property
-    def mimetype(self) -> str:
-        content_type = self.request.headers.get("Content-Type")
-        if content_type:
-            return content_type.partition(";")[0]
-
-        return ""
+    def content_type(self) -> str:
+        # default value according to RFC 2616
+        return (
+            self.request.headers.get("Content-Type")
+            or "application/octet-stream"
+        )

--- a/openapi_core/contrib/starlette/responses.py
+++ b/openapi_core/contrib/starlette/responses.py
@@ -21,8 +21,8 @@ class StarletteOpenAPIResponse:
         return self.response.status_code
 
     @property
-    def mimetype(self) -> str:
-        return self.response.media_type or ""
+    def content_type(self) -> str:
+        return self.response.headers.get("Content-Type") or ""
 
     @property
     def headers(self) -> Headers:

--- a/openapi_core/contrib/werkzeug/requests.py
+++ b/openapi_core/contrib/werkzeug/requests.py
@@ -43,8 +43,9 @@ class WerkzeugOpenAPIRequest:
         return self.request.get_data(as_text=True)
 
     @property
-    def mimetype(self) -> str:
-        return self.request.mimetype
+    def content_type(self) -> str:
+        # default value according to RFC 2616
+        return self.request.content_type or "application/octet-stream"
 
     def get_path(self, path: str) -> str:
         return "".join([self.request.root_path, path])

--- a/openapi_core/contrib/werkzeug/responses.py
+++ b/openapi_core/contrib/werkzeug/responses.py
@@ -18,7 +18,7 @@ class WerkzeugOpenAPIResponse:
         return self.response._status_code
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         return str(self.response.mimetype)
 
     @property

--- a/openapi_core/protocols.py
+++ b/openapi_core/protocols.py
@@ -21,7 +21,7 @@ class BaseRequest(Protocol):
         ...
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         ...
 
 
@@ -48,11 +48,9 @@ class Request(BaseRequest, Protocol):
             to write resolved path parameters.
         body
             The request body, as string.
-        mimetype
-            Like content type, but without parameters (eg, without charset,
-            type etc.) and always lowercase.
-            For example if the content type is "text/HTML; charset=utf-8"
-            the mimetype would be "text/html".
+        content_type
+            The content type with parameters (eg, charset, boundary etc.)
+            and always lowercase.
     """
 
     @property
@@ -78,11 +76,9 @@ class WebhookRequest(BaseRequest, Protocol):
             to write resolved path parameters.
         body
             The request body, as string.
-        mimetype
-            Like content type, but without parameters (eg, without charset,
-            type etc.) and always lowercase.
-            For example if the content type is "text/HTML; charset=utf-8"
-            the mimetype would be "text/html".
+        content_type
+            The content type with parameters (eg, charset, boundary etc.)
+            and always lowercase.
     """
 
     @property

--- a/openapi_core/protocols.py
+++ b/openapi_core/protocols.py
@@ -115,8 +115,8 @@ class Response(Protocol):
             The status code as integer.
         headers
             Response headers as Headers.
-        mimetype
-            Lowercase content type without charset.
+        content_type
+            The content type with parameters and always lowercase.
     """
 
     @property
@@ -128,7 +128,7 @@ class Response(Protocol):
         ...
 
     @property
-    def mimetype(self) -> str:
+    def content_type(self) -> str:
         ...
 
     @property

--- a/openapi_core/testing/requests.py
+++ b/openapi_core/testing/requests.py
@@ -21,7 +21,7 @@ class MockRequest:
         headers: Optional[Dict[str, Any]] = None,
         cookies: Optional[Dict[str, Any]] = None,
         data: Optional[str] = None,
-        mimetype: str = "application/json",
+        content_type: str = "application/json",
     ):
         self.host_url = host_url
         self.method = method.lower()
@@ -32,7 +32,7 @@ class MockRequest:
         self.headers = headers
         self.cookies = cookies
         self.body = data or ""
-        self.mimetype = mimetype
+        self.content_type = content_type
 
         self.parameters = RequestParameters(
             path=self.view_args or {},

--- a/openapi_core/testing/responses.py
+++ b/openapi_core/testing/responses.py
@@ -12,9 +12,9 @@ class MockResponse:
         data: str,
         status_code: int = 200,
         headers: Optional[Dict[str, Any]] = None,
-        mimetype: str = "application/json",
+        content_type: str = "application/json",
     ):
         self.data = data
         self.status_code = status_code
         self.headers = Headers(headers or {})
-        self.mimetype = mimetype
+        self.content_type = content_type

--- a/openapi_core/unmarshalling/request/unmarshallers.py
+++ b/openapi_core/unmarshalling/request/unmarshallers.py
@@ -150,7 +150,9 @@ class BaseRequestUnmarshaller(BaseRequestValidator, BaseUnmarshaller):
             params_errors = []
 
         try:
-            body = self._get_body(request.body, request.mimetype, operation)
+            body = self._get_body(
+                request.body, request.content_type, operation
+            )
         except MissingRequestBody:
             body = None
             body_errors = []
@@ -172,7 +174,9 @@ class BaseRequestUnmarshaller(BaseRequestValidator, BaseUnmarshaller):
         self, request: BaseRequest, operation: SchemaPath, path: SchemaPath
     ) -> RequestUnmarshalResult:
         try:
-            body = self._get_body(request.body, request.mimetype, operation)
+            body = self._get_body(
+                request.body, request.content_type, operation
+            )
         except MissingRequestBody:
             body = None
             errors = []

--- a/openapi_core/unmarshalling/response/unmarshallers.py
+++ b/openapi_core/unmarshalling/response/unmarshallers.py
@@ -66,7 +66,7 @@ class BaseResponseUnmarshaller(BaseResponseValidator, BaseUnmarshaller):
 
         try:
             validated_data = self._get_data(
-                response.data, response.mimetype, operation_response
+                response.data, response.content_type, operation_response
             )
         except DataValidationError as exc:
             validated_data = None
@@ -106,7 +106,7 @@ class BaseResponseUnmarshaller(BaseResponseValidator, BaseUnmarshaller):
 
         try:
             validated = self._get_data(
-                response.data, response.mimetype, operation_response
+                response.data, response.content_type, operation_response
             )
         except DataValidationError as exc:
             validated = None

--- a/openapi_core/validation/request/validators.py
+++ b/openapi_core/validation/request/validators.py
@@ -111,7 +111,7 @@ class BaseRequestValidator(BaseValidator):
             yield from exc.errors
 
         try:
-            self._get_body(request.body, request.mimetype, operation)
+            self._get_body(request.body, request.content_type, operation)
         except RequestBodyValidationError as exc:
             yield exc
 
@@ -119,7 +119,7 @@ class BaseRequestValidator(BaseValidator):
         self, request: BaseRequest, operation: SchemaPath
     ) -> Iterator[Exception]:
         try:
-            self._get_body(request.body, request.mimetype, operation)
+            self._get_body(request.body, request.content_type, operation)
         except RequestBodyValidationError as exc:
             yield exc
 

--- a/openapi_core/validation/response/validators.py
+++ b/openapi_core/validation/response/validators.py
@@ -234,7 +234,10 @@ class APICallResponseDataValidator(BaseAPICallResponseValidator):
             return
 
         yield from self._iter_data_errors(
-            response.status_code, response.data, response.mimetype, operation
+            response.status_code,
+            response.data,
+            response.content_type,
+            operation,
         )
 
 
@@ -273,7 +276,7 @@ class APICallResponseValidator(BaseAPICallResponseValidator):
             response.status_code,
             response.data,
             response.headers,
-            response.mimetype,
+            response.content_type,
             operation,
         )
 
@@ -292,7 +295,10 @@ class WebhookResponseDataValidator(BaseWebhookResponseValidator):
             return
 
         yield from self._iter_data_errors(
-            response.status_code, response.data, response.mimetype, operation
+            response.status_code,
+            response.data,
+            response.content_type,
+            operation,
         )
 
 
@@ -331,7 +337,7 @@ class WebhookResponseValidator(BaseWebhookResponseValidator):
             response.status_code,
             response.data,
             response.headers,
-            response.mimetype,
+            response.content_type,
             operation,
         )
 

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -1015,7 +1015,7 @@ class TestPetstore:
             "/pets",
             path_pattern=path_pattern,
             data=data,
-            mimetype="text/html",
+            content_type="text/html",
             headers=headers,
             cookies=cookies,
         )
@@ -1150,7 +1150,7 @@ class TestPetstore:
             "/pets",
             path_pattern=path_pattern,
             data=data,
-            mimetype="text/html",
+            content_type="text/html",
             headers=headers,
             cookies=cookies,
         )

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -195,7 +195,7 @@ class TestPetstore:
         assert response_result.data.data[0].id == 1
         assert response_result.data.data[0].name == "Cat"
 
-    def test_get_pets_response_no_schema(self, spec):
+    def test_get_pets_response_media_type(self, spec):
         host_url = "http://petstore.swagger.io/v1"
         path_pattern = "/v1/pets"
         query_params = {
@@ -230,15 +230,15 @@ class TestPetstore:
 
         assert result.body is None
 
-        data = b"<html></html>"
+        data = b"<html>\xb1\xbc</html>"
         response = MockResponse(
-            data, status_code=404, mimetype="text/html; charset=utf-8"
+            data, status_code=404, content_type="text/html; charset=iso-8859-2"
         )
 
         response_result = unmarshal_response(request, response, spec=spec)
 
         assert response_result.errors == []
-        assert response_result.data == data.decode("utf-8")
+        assert response_result.data == data.decode("iso-8859-2")
 
     def test_get_pets_invalid_response(self, spec, response_unmarshaller):
         host_url = "http://petstore.swagger.io/v1"
@@ -1372,7 +1372,7 @@ class TestPetstore:
         assert result.body is None
 
         data = b"imagedata"
-        response = MockResponse(data, mimetype="image/png")
+        response = MockResponse(data, content_type="image/png")
 
         response_result = unmarshal_response(request, response, spec=spec)
 

--- a/tests/integration/unmarshalling/test_request_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_request_unmarshaller.py
@@ -186,7 +186,7 @@ class TestRequestUnmarshaller:
             "post",
             "/v1/pets",
             path_pattern="/v1/pets",
-            mimetype="text/csv",
+            content_type="text/csv",
             data=data,
             headers=headers,
             cookies=cookies,
@@ -349,7 +349,7 @@ class TestRequestUnmarshaller:
             data=data,
             headers=headers,
             cookies=cookies,
-            mimetype="text/plain",
+            content_type="text/plain",
         )
 
         result = request_unmarshaller.unmarshal(request)

--- a/tests/integration/unmarshalling/test_response_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_response_unmarshaller.py
@@ -72,7 +72,7 @@ class TestResponseUnmarshaller:
 
     def test_invalid_content_type(self, response_unmarshaller):
         request = MockRequest(self.host_url, "get", "/v1/pets")
-        response = MockResponse("Not Found", mimetype="text/csv")
+        response = MockResponse("Not Found", content_type="text/csv")
 
         result = response_unmarshaller.unmarshal(request, response)
 

--- a/tests/integration/validation/test_request_validators.py
+++ b/tests/integration/validation/test_request_validators.py
@@ -101,7 +101,7 @@ class TestRequestValidator:
             "post",
             "/v1/pets",
             path_pattern="/v1/pets",
-            mimetype="text/csv",
+            content_type="text/csv",
             data=data,
             headers=headers,
             cookies=cookies,

--- a/tests/integration/validation/test_response_validators.py
+++ b/tests/integration/validation/test_response_validators.py
@@ -61,7 +61,7 @@ class TestResponseValidator:
 
     def test_invalid_content_type(self, response_validator):
         request = MockRequest(self.host_url, "get", "/v1/pets")
-        response = MockResponse("Not Found", mimetype="text/csv")
+        response = MockResponse("Not Found", content_type="text/csv")
 
         with pytest.raises(DataValidationError) as exc_info:
             response_validator.validate(request, response)

--- a/tests/unit/contrib/django/test_django.py
+++ b/tests/unit/contrib/django/test_django.py
@@ -184,7 +184,7 @@ class TestDjangoOpenAPIResponse(BaseTestDjango):
 
         assert openapi_response.data == "foo\nbar\nbaz\n"
         assert openapi_response.status_code == response.status_code
-        assert openapi_response.mimetype == response["Content-Type"]
+        assert openapi_response.content_type == response["Content-Type"]
 
     def test_redirect_response(self, response_factory):
         data = "/redirected/"
@@ -194,4 +194,4 @@ class TestDjangoOpenAPIResponse(BaseTestDjango):
 
         assert openapi_response.data == data
         assert openapi_response.status_code == response.status_code
-        assert openapi_response.mimetype == response["Content-Type"]
+        assert openapi_response.content_type == response["Content-Type"]

--- a/tests/unit/contrib/django/test_django.py
+++ b/tests/unit/contrib/django/test_django.py
@@ -84,7 +84,7 @@ class TestDjangoOpenAPIRequest(BaseTestDjango):
         assert openapi_request.path == request.path
         assert openapi_request.path_pattern is None
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.content_type
+        assert openapi_request.content_type == request.content_type
 
     def test_simple(self, request_factory):
         from django.urls import resolve
@@ -105,7 +105,7 @@ class TestDjangoOpenAPIRequest(BaseTestDjango):
         assert openapi_request.path == request.path
         assert openapi_request.path_pattern == request.path
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.content_type
+        assert openapi_request.content_type == request.content_type
 
     def test_url_rule(self, request_factory):
         from django.urls import resolve
@@ -126,7 +126,7 @@ class TestDjangoOpenAPIRequest(BaseTestDjango):
         assert openapi_request.path == request.path
         assert openapi_request.path_pattern == "/admin/auth/group/{object_id}/"
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.content_type
+        assert openapi_request.content_type == request.content_type
 
     def test_url_regexp_pattern(self, request_factory):
         from django.urls import resolve
@@ -147,7 +147,7 @@ class TestDjangoOpenAPIRequest(BaseTestDjango):
         assert openapi_request.path == request.path
         assert openapi_request.path_pattern == request.path
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.content_type
+        assert openapi_request.content_type == request.content_type
 
     def test_drf_default_value_pattern(self, request_factory):
         from django.urls import resolve
@@ -168,7 +168,7 @@ class TestDjangoOpenAPIRequest(BaseTestDjango):
         assert openapi_request.path == request.path
         assert openapi_request.path_pattern == "/object/{pk}/action/"
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.content_type
+        assert openapi_request.content_type == request.content_type
 
 
 class TestDjangoOpenAPIResponse(BaseTestDjango):

--- a/tests/unit/contrib/flask/test_flask_requests.py
+++ b/tests/unit/contrib/flask/test_flask_requests.py
@@ -32,7 +32,7 @@ class TestFlaskOpenAPIRequest:
         assert openapi_request.host_url == request.host_url
         assert openapi_request.path == request.path
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.mimetype
+        assert openapi_request.content_type == "application/octet-stream"
 
     def test_multiple_values(self, request_factory, request):
         request = request_factory(
@@ -60,7 +60,7 @@ class TestFlaskOpenAPIRequest:
         assert openapi_request.host_url == request.host_url
         assert openapi_request.path == request.path
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.mimetype
+        assert openapi_request.content_type == "application/octet-stream"
 
     def test_url_rule(self, request_factory, request):
         request = request_factory("GET", "/browse/12/", subdomain="kb")
@@ -82,4 +82,4 @@ class TestFlaskOpenAPIRequest:
         assert openapi_request.path == request.path
         assert openapi_request.path_pattern == "/browse/{id}/"
         assert openapi_request.body == ""
-        assert openapi_request.mimetype == request.mimetype
+        assert openapi_request.content_type == "application/octet-stream"

--- a/tests/unit/contrib/flask/test_flask_responses.py
+++ b/tests/unit/contrib/flask/test_flask_responses.py
@@ -17,4 +17,4 @@ class TestFlaskOpenAPIResponse:
 
         assert openapi_response.data == data
         assert openapi_response.status_code == status_code
-        assert openapi_response.mimetype == response.mimetype
+        assert openapi_response.content_type == response.mimetype

--- a/tests/unit/contrib/requests/test_requests_requests.py
+++ b/tests/unit/contrib/requests/test_requests_requests.py
@@ -31,7 +31,7 @@ class TestRequestsOpenAPIRequest:
         assert openapi_request.host_url == "http://localhost"
         assert openapi_request.path == "/"
         assert openapi_request.body == prepared.body
-        assert openapi_request.mimetype == "application/json"
+        assert openapi_request.content_type == "application/json"
 
     def test_multiple_values(self, request_factory, request):
         request = request_factory(
@@ -60,7 +60,7 @@ class TestRequestsOpenAPIRequest:
         assert openapi_request.host_url == "http://localhost"
         assert openapi_request.path == "/"
         assert openapi_request.body == prepared.body
-        assert openapi_request.mimetype == "application/json"
+        assert openapi_request.content_type == "application/json"
 
     def test_url_rule(self, request_factory, request):
         request = request_factory("GET", "/browse/12/", subdomain="kb")
@@ -87,7 +87,7 @@ class TestRequestsOpenAPIRequest:
         assert openapi_request.host_url == "http://localhost"
         assert openapi_request.path == "/browse/12/"
         assert openapi_request.body == prepared.body
-        assert openapi_request.mimetype == "application/json"
+        assert openapi_request.content_type == "application/json"
 
     def test_hash_param(self, request_factory, request):
         request = request_factory("GET", "/browse/#12", subdomain="kb")
@@ -114,7 +114,7 @@ class TestRequestsOpenAPIRequest:
         assert openapi_request.host_url == "http://localhost"
         assert openapi_request.path == "/browse/#12"
         assert openapi_request.body == prepared.body
-        assert openapi_request.mimetype == "application/json"
+        assert openapi_request.content_type == "application/json"
 
     def test_content_type_with_charset(self, request_factory, request):
         request = request_factory(
@@ -141,4 +141,6 @@ class TestRequestsOpenAPIRequest:
         assert openapi_request.host_url == "http://localhost"
         assert openapi_request.path == "/"
         assert openapi_request.body == prepared.body
-        assert openapi_request.mimetype == "application/json"
+        assert (
+            openapi_request.content_type == "application/json; charset=utf-8"
+        )

--- a/tests/unit/contrib/requests/test_requests_responses.py
+++ b/tests/unit/contrib/requests/test_requests_responses.py
@@ -18,4 +18,4 @@ class TestRequestsOpenAPIResponse:
         assert openapi_response.data == data
         assert openapi_response.status_code == status_code
         mimetype = response.headers.get("Content-Type")
-        assert openapi_response.mimetype == mimetype
+        assert openapi_response.content_type == mimetype


### PR DESCRIPTION
Update Request and Response protocols. Move `mimetype` to `content_type` to include content parameters. Required to work with media type deserializing.

Backward incompatibility