### PR TITLE
Deprecated spec validator fix

### DIFF
--- a/openapi_core/unmarshalling/schemas/unmarshallers.py
+++ b/openapi_core/unmarshalling/schemas/unmarshallers.py
@@ -45,7 +45,7 @@ class ArrayUnmarshaller(PrimitiveUnmarshaller):
     def items_unmarshaller(self) -> "SchemaUnmarshaller":
         # sometimes we don't have any schema i.e. free-form objects
         items_schema = self.schema.get(
-            "items", Spec.from_dict({}, validator=None)
+            "items", Spec.from_dict({}, spec_validator_cls=None)
         )
         return self.schema_unmarshaller.evolve(items_schema)
 
@@ -120,7 +120,7 @@ class ObjectUnmarshaller(PrimitiveUnmarshaller):
             # free-form object
             if additional_properties is True:
                 additional_prop_schema = Spec.from_dict(
-                    {"nullable": True}, validator=None
+                    {"nullable": True}, spec_validator_cls=None
                 )
             # defined schema
             else:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1042,6 +1042,23 @@ format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validat
 format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.3.1"
+description = "JSONSchema Spec with object-oriented paths"
+optional = false
+python-versions = ">=3.8.0,<4.0.0"
+files = [
+    {file = "jsonschema_path-0.3.1-py3-none-any.whl", hash = "sha256:06f01b1848a28963f49a17730e11204d252aa6ff5db4ef84ec77e5ac93cfa831"},
+    {file = "jsonschema_path-0.3.1.tar.gz", hash = "sha256:07ea584b5c9b41a614b4d011c5575955676f48d0abbfd93d9ea8e933018d716d"},
+]
+
+[package.dependencies]
+pathable = ">=0.4.1,<0.5.0"
+PyYAML = ">=5.1"
+referencing = ">=0.28.0,<0.31.0"
+requests = ">=2.31.0,<3.0.0"
+
+[[package]]
 name = "jsonschema-spec"
 version = "0.2.4"
 description = "JSONSchema Spec with object-oriented paths"
@@ -1381,19 +1398,19 @@ rfc3339-validator = "*"
 
 [[package]]
 name = "openapi-spec-validator"
-version = "0.6.0"
+version = "0.7.1"
 description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3 spec validator"
 optional = false
 python-versions = ">=3.8.0,<4.0.0"
 files = [
-    {file = "openapi_spec_validator-0.6.0-py3-none-any.whl", hash = "sha256:675f1a3c0d0d8eff9116694acde88bcd4613a95bf5240270724d9d78c78f26d6"},
-    {file = "openapi_spec_validator-0.6.0.tar.gz", hash = "sha256:68c4c212c88ef14c6b1a591b895bf742c455783c7ebba2507abd7dbc1365a616"},
+    {file = "openapi_spec_validator-0.7.1-py3-none-any.whl", hash = "sha256:3c81825043f24ccbcd2f4b149b11e8231abce5ba84f37065e14ec947d8f4e959"},
+    {file = "openapi_spec_validator-0.7.1.tar.gz", hash = "sha256:8577b85a8268685da6f8aa30990b83b7960d4d1117e901d451b5d572605e5ec7"},
 ]
 
 [package.dependencies]
-importlib-resources = {version = ">=5.8.0,<6.0.0", markers = "python_version < \"3.9\""}
+importlib-resources = {version = ">=5.8,<7.0", markers = "python_version < \"3.9\""}
 jsonschema = ">=4.18.0,<5.0.0"
-jsonschema-spec = ">=0.2.3,<0.3.0"
+jsonschema-path = ">=0.3.1,<0.4.0"
 lazy-object-proxy = ">=1.7.1,<2.0.0"
 openapi-schema-validator = ">=0.6.0,<0.7.0"
 
@@ -2483,4 +2500,4 @@ starlette = ["starlette"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "80ad9a19a5925d231dfd01e7d7f5637190b54daa5c925e8431ae5cd69333ec25"
+content-hash = "ba83953f64ddd115eff950908eaf6ef449ada14079713f75d1c79a7d39f50c7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ isodate = "*"
 more-itertools = "*"
 parse = "*"
 openapi-schema-validator = "^0.6.0"
-openapi-spec-validator = "^0.6.0"
+openapi-spec-validator = "^0.7.1"
 requests = {version = "*", optional = true}
 werkzeug = "*"
 jsonschema-spec = "^0.2.3"

--- a/tests/integration/contrib/django/data/v3.0/djangoproject/settings.py
+++ b/tests/integration/contrib/django/data/v3.0/djangoproject/settings.py
@@ -103,8 +103,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/tests/integration/contrib/requests/test_requests_validation.py
+++ b/tests/integration/contrib/requests/test_requests_validation.py
@@ -40,7 +40,6 @@ class TestRequestsOpenAPIValidation:
             "http://localhost/browse/12/?q=string",
             json={"data": "data"},
             status=200,
-            match_querystring=True,
             headers={"X-Rate-Limit": "12"},
         )
         request = requests.Request(

--- a/tests/integration/schema/test_spec.py
+++ b/tests/integration/schema/test_spec.py
@@ -1,8 +1,8 @@
 from base64 import b64encode
 
 import pytest
-from openapi_spec_validator import openapi_v30_spec_validator
-from openapi_spec_validator import openapi_v31_spec_validator
+from openapi_spec_validator import OpenAPIV30SpecValidator
+from openapi_spec_validator import OpenAPIV31SpecValidator
 
 from openapi_core import Spec
 from openapi_core import V30RequestValidator
@@ -32,7 +32,9 @@ class TestPetstore:
     @pytest.fixture
     def spec(self, spec_dict, base_uri):
         return Spec.from_dict(
-            spec_dict, base_uri=base_uri, validator=openapi_v30_spec_validator
+            spec_dict,
+            base_uri=base_uri,
+            spec_validator_cls=OpenAPIV30SpecValidator,
         )
 
     @pytest.fixture
@@ -327,7 +329,7 @@ class TestWebhook:
         return Spec.from_dict(
             spec_dict,
             base_uri=base_uri,
-            validator=openapi_v31_spec_validator,
+            spec_validator_cls=OpenAPIV31SpecValidator,
         )
 
     @pytest.fixture

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -97,11 +97,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -153,11 +156,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -210,11 +216,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -253,11 +262,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -322,11 +334,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -371,11 +386,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -420,12 +438,15 @@ class TestPetstore:
             args=query_params,
         )
 
-        with pytest.raises(ParameterValidationError) as exc_info:
-            validate_request(
-                request,
-                spec=spec,
-                cls=V30RequestParametersUnmarshaller,
-            )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            with pytest.raises(ParameterValidationError) as exc_info:
+                validate_request(
+                    request,
+                    spec=spec,
+                    cls=V30RequestParametersUnmarshaller,
+                )
         assert type(exc_info.value.__cause__) is DeserializeError
 
         result = unmarshal_request(
@@ -449,12 +470,15 @@ class TestPetstore:
             args=query_params,
         )
 
-        with pytest.raises(ParameterValidationError) as exc_info:
-            validate_request(
-                request,
-                spec=spec,
-                cls=V30RequestParametersValidator,
-            )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            with pytest.raises(ParameterValidationError) as exc_info:
+                validate_request(
+                    request,
+                    spec=spec,
+                    cls=V30RequestParametersValidator,
+                )
         assert type(exc_info.value.__cause__) is CastError
 
         result = unmarshal_request(
@@ -473,12 +497,15 @@ class TestPetstore:
             path_pattern=path_pattern,
         )
 
-        with pytest.raises(MissingRequiredParameter):
-            validate_request(
-                request,
-                spec=spec,
-                cls=V30RequestParametersValidator,
-            )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            with pytest.raises(MissingRequiredParameter):
+                validate_request(
+                    request,
+                    spec=spec,
+                    cls=V30RequestParametersValidator,
+                )
 
         result = unmarshal_request(
             request, spec=spec, cls=V30RequestBodyUnmarshaller
@@ -501,12 +528,15 @@ class TestPetstore:
             args=query_params,
         )
 
-        with pytest.raises(ParameterValidationError) as exc_info:
-            validate_request(
-                request,
-                spec=spec,
-                cls=V30RequestParametersValidator,
-            )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            with pytest.raises(ParameterValidationError) as exc_info:
+                validate_request(
+                    request,
+                    spec=spec,
+                    cls=V30RequestParametersValidator,
+                )
         assert type(exc_info.value.__cause__) is EmptyQueryParameterValue
 
         result = unmarshal_request(
@@ -531,11 +561,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -566,11 +599,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -602,11 +638,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert result.parameters == Parameters(
             query={
@@ -643,11 +682,14 @@ class TestPetstore:
             args=query_params,
         )
 
-        result = unmarshal_request(
-            request,
-            spec=spec,
-            cls=V30RequestParametersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="limit parameter is deprecated"
+        ):
+            result = unmarshal_request(
+                request,
+                spec=spec,
+                cls=V30RequestParametersUnmarshaller,
+            )
 
         assert is_dataclass(result.parameters.query["coordinates"])
         assert (
@@ -1785,16 +1827,22 @@ class TestPetstore:
         }
         response = MockResponse(data, status_code=200, headers=headers)
 
-        response_result = unmarshal_response(request, response, spec=spec)
+        with pytest.warns(
+            DeprecationWarning, match="x-delete-confirm header is deprecated"
+        ):
+            response_result = unmarshal_response(request, response, spec=spec)
         assert response_result.errors == []
         assert response_result.data is None
 
-        result = unmarshal_response(
-            request,
-            response,
-            spec=spec,
-            cls=V30ResponseHeadersUnmarshaller,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="x-delete-confirm header is deprecated"
+        ):
+            result = unmarshal_response(
+                request,
+                response,
+                spec=spec,
+                cls=V30ResponseHeadersUnmarshaller,
+            )
 
         assert result.headers == {
             "x-delete-confirm": True,

--- a/tests/integration/unmarshalling/test_request_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_request_unmarshaller.py
@@ -116,8 +116,8 @@ class TestRequestUnmarshaller:
             "api_key": self.api_key,
         }
 
-    def test_get_pets_webob(self, request_unmarshaller):
-        from webob.multidict import GetDict
+    def test_get_pets_multidict(self, request_unmarshaller):
+        from multidict import MultiDict
 
         request = MockRequest(
             self.host_url,
@@ -125,8 +125,8 @@ class TestRequestUnmarshaller:
             "/v1/pets",
             path_pattern="/v1/pets",
         )
-        request.parameters.query = GetDict(
-            [("limit", "5"), ("ids", "1"), ("ids", "2")], {}
+        request.parameters.query = MultiDict(
+            [("limit", "5"), ("ids", "1"), ("ids", "2")],
         )
 
         with pytest.warns(DeprecationWarning):

--- a/tests/integration/unmarshalling/test_unmarshallers.py
+++ b/tests/integration/unmarshalling/test_unmarshallers.py
@@ -34,7 +34,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "deprecated": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         with pytest.warns(DeprecationWarning):
             unmarshallers_factory.create(spec)
 
@@ -44,7 +44,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(
             FormatterNotFoundError,
@@ -66,7 +66,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
     )
     def test_no_type(self, unmarshallers_factory, value):
         schema = {}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -89,7 +89,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "type": type,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -144,7 +144,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "type": type,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(
@@ -190,7 +190,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -233,7 +233,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": type,
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -257,7 +257,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": type,
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -279,7 +279,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": type,
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -300,7 +300,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": "byte",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -312,7 +312,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": "date",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "2018-01-02"
 
@@ -335,7 +335,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": "date-time",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -347,7 +347,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": "date-time",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "2018-01-02T00:00:00"
 
@@ -363,7 +363,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": "password",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "passwd"
 
@@ -376,7 +376,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": "uuid",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = str(uuid4())
 
@@ -389,7 +389,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "format": "uuid",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "test"
 
@@ -418,7 +418,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": type,
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -431,7 +431,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "pattern": "bar",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -452,7 +452,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "pattern": pattern,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -469,7 +469,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "minLength": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -482,7 +482,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "minLength": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -499,7 +499,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "maxLength": 1,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -512,7 +512,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "maxLength": 1,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -535,7 +535,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "string",
             "maxLength": -1,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -546,7 +546,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "integer",
             "enum": [1, 2, 3],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = 2
 
@@ -560,7 +560,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "integer",
             "enum": enum,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = 12
 
@@ -591,7 +591,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 "type": type,
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value_list = [value] * 3
 
@@ -617,7 +617,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 "type": type,
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -637,7 +637,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             },
             "minItems": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -656,7 +656,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             },
             "minItems": 0,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -679,7 +679,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             },
             "maxItems": -1,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -694,7 +694,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             },
             "maxItems": 1,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -713,7 +713,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             },
             "uniqueItems": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -740,7 +740,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = {"someint": 1}
 
@@ -764,7 +764,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -799,7 +799,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         assert unmarshaller.unmarshal({"someint": 1}) == {
@@ -830,7 +830,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         assert unmarshaller.unmarshal({"someint": "1"}) == {
@@ -862,7 +862,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         assert unmarshaller.unmarshal({}) == {
@@ -897,7 +897,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -941,7 +941,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             },
             "additionalProperties": False,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -963,7 +963,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 }
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -983,7 +983,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "object",
             "additionalProperties": False,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1005,7 +1005,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "object",
             "additionalProperties": additional_properties,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1014,7 +1014,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
 
     def test_object_additional_properties_list(self, unmarshallers_factory):
         schema = {"type": "object"}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal({"user_ids": [1, 2, 3, 4]})
@@ -1033,7 +1033,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "type": "object",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1056,7 +1056,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "object",
             "additionalProperties": additional_properties,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1077,7 +1077,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "properties": {k: {"type": "number"} for k in ["a", "b", "c"]},
             "minProperties": 1,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1098,7 +1098,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "properties": {k: {"type": "number"} for k in ["a", "b", "c"]},
             "minProperties": 4,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1117,7 +1117,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "object",
             "minProperties": 2,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1137,7 +1137,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "properties": {k: {"type": "number"} for k in ["a", "b", "c"]},
             "maxProperties": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1158,7 +1158,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "properties": {k: {"type": "number"} for k in ["a", "b", "c"]},
             "maxProperties": 0,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1177,7 +1177,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "object",
             "maxProperties": -1,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1197,7 +1197,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = ["hello"]
 
@@ -1219,7 +1219,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = ["hello"]
 
@@ -1238,7 +1238,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 }
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = ["hello"]
 
@@ -1292,7 +1292,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             ],
             "additionalProperties": False,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1308,7 +1308,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "2018-01-02"
 
@@ -1326,7 +1326,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "2018-01-02"
 
@@ -1344,7 +1344,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "2018-01-02"
 
@@ -1362,7 +1362,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
                 },
             ],
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = "2018-01-02"
 
@@ -1400,7 +1400,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "anyOf": any_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1440,7 +1440,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "oneOf": one_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1457,7 +1457,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "anyOf": any_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1481,7 +1481,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "oneOf": one_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1528,7 +1528,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "anyOf": any_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1554,7 +1554,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "object",
             "anyOf": any_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1580,7 +1580,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
             "type": "object",
             "oneOf": one_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue):
@@ -1629,7 +1629,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
         schema = {
             "oneOf": one_of,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1640,7 +1640,7 @@ class BaseTestOASSchemaUnmarshallersFactoryCall:
 class BaseTestOASS30chemaUnmarshallersFactoryCall:
     def test_null_undefined(self, unmarshallers_factory):
         schema = {"type": "null"}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(UnknownType):
@@ -1658,7 +1658,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
     )
     def test_nullable(self, unmarshallers_factory, type):
         schema = {"type": type, "nullable": True}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(None)
@@ -1677,7 +1677,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
     )
     def test_not_nullable(self, unmarshallers_factory, type):
         schema = {"type": type}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(
@@ -1708,7 +1708,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
             "type": type,
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -1729,7 +1729,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
             "type": type,
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(
@@ -1753,7 +1753,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
         schema = {
             "type": "string",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = b"true"
 
@@ -1785,7 +1785,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
         self, unmarshallers_factory, types, value
     ):
         schema = {"type": types}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(SchemaError):
@@ -1798,7 +1798,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
             "default": default_value,
             "nullable": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = None
 
@@ -1814,7 +1814,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
             },
             "nullable": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = None
 
@@ -1832,7 +1832,7 @@ class BaseTestOASS30chemaUnmarshallersFactoryCall:
                 }
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = {"foo": None}
 
@@ -1860,7 +1860,7 @@ class TestOAS30RequestSchemaUnmarshallersFactory(
                 }
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = {"id": 10}
 
@@ -1880,7 +1880,7 @@ class TestOAS30RequestSchemaUnmarshallersFactory(
                 }
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
         value = {"id": 10}
 
@@ -1908,7 +1908,7 @@ class TestOAS30ResponseSchemaUnmarshallersFactory(
                 }
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         # readOnly properties may be admitted in a Response context
@@ -1929,7 +1929,7 @@ class TestOAS30ResponseSchemaUnmarshallersFactory(
                 }
             },
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         # readOnly properties are not admitted on a Request context
@@ -1965,7 +1965,7 @@ class TestOAS31SchemaUnmarshallersFactory(
             "type": type,
             "format": format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(FormatterNotFoundError):
             unmarshallers_factory.create(spec)
@@ -1985,7 +1985,7 @@ class TestOAS31SchemaUnmarshallersFactory(
         schema = {
             "type": type,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(
@@ -1996,7 +1996,7 @@ class TestOAS31SchemaUnmarshallersFactory(
 
     def test_null(self, unmarshallers_factory):
         schema = {"type": "null"}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(None)
@@ -2006,7 +2006,7 @@ class TestOAS31SchemaUnmarshallersFactory(
     @pytest.mark.parametrize("value", ["string", 2, 3.14, True, [1, 2], {}])
     def test_null_invalid(self, unmarshallers_factory, value):
         schema = {"type": "null"}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -2029,7 +2029,7 @@ class TestOAS31SchemaUnmarshallersFactory(
     )
     def test_nultiple_types(self, unmarshallers_factory, types, value):
         schema = {"type": types}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(value)
@@ -2049,7 +2049,7 @@ class TestOAS31SchemaUnmarshallersFactory(
     )
     def test_nultiple_types_invalid(self, unmarshallers_factory, types, value):
         schema = {"type": types}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         with pytest.raises(InvalidSchemaValue) as exc_info:
@@ -2059,7 +2059,7 @@ class TestOAS31SchemaUnmarshallersFactory(
 
     def test_any_null(self, unmarshallers_factory):
         schema = {}
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         unmarshaller = unmarshallers_factory.create(spec)
 
         result = unmarshaller.unmarshal(None)

--- a/tests/unit/casting/test_schema_casters.py
+++ b/tests/unit/casting/test_schema_casters.py
@@ -20,7 +20,7 @@ class TestSchemaCaster:
                 "type": "number",
             },
         }
-        schema = Spec.from_dict(spec, validator=None)
+        schema = Spec.from_dict(spec, spec_validator_cls=None)
         value = ["test", "test2"]
 
         with pytest.raises(CastError):
@@ -34,7 +34,7 @@ class TestSchemaCaster:
                 "oneOf": [{"type": "number"}, {"type": "string"}],
             },
         }
-        schema = Spec.from_dict(spec, validator=None)
+        schema = Spec.from_dict(spec, spec_validator_cls=None)
 
         with pytest.raises(
             CastError, match=f"Failed to cast value to array type: {value}"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,14 +5,14 @@ from openapi_core import Spec
 
 @pytest.fixture
 def spec_v30():
-    return Spec.from_dict({"openapi": "3.0"}, validator=None)
+    return Spec.from_dict({"openapi": "3.0"}, spec_validator_cls=None)
 
 
 @pytest.fixture
 def spec_v31():
-    return Spec.from_dict({"openapi": "3.1"}, validator=None)
+    return Spec.from_dict({"openapi": "3.1"}, spec_validator_cls=None)
 
 
 @pytest.fixture
 def spec_invalid():
-    return Spec.from_dict({}, validator=None)
+    return Spec.from_dict({}, spec_validator_cls=None)

--- a/tests/unit/deserializing/test_parameters_deserializers.py
+++ b/tests/unit/deserializing/test_parameters_deserializers.py
@@ -19,7 +19,7 @@ class TestParameterDeserializer:
 
     def test_unsupported(self, deserializer_factory):
         spec = {"name": "param", "in": "header", "style": "unsupported"}
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         deserializer = deserializer_factory(param)
         value = ""
 
@@ -33,7 +33,7 @@ class TestParameterDeserializer:
             "name": "param",
             "in": "query",
         }
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         deserializer = deserializer_factory(param)
         value = ""
 
@@ -45,7 +45,7 @@ class TestParameterDeserializer:
             "name": "param",
             "in": "query",
         }
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         deserializer = deserializer_factory(param)
         value = "test"
 

--- a/tests/unit/extensions/test_factories.py
+++ b/tests/unit/extensions/test_factories.py
@@ -27,7 +27,9 @@ class TestImportModelCreate:
     def test_dynamic_model(self):
         factory = ModelPathFactory()
 
-        schema = Spec.from_dict({"x-model": "TestModel"}, validator=None)
+        schema = Spec.from_dict(
+            {"x-model": "TestModel"}, spec_validator_cls=None
+        )
         test_model_class = factory.create(schema, ["name"])
 
         assert is_dataclass(test_model_class)
@@ -39,7 +41,7 @@ class TestImportModelCreate:
         factory = ModelPathFactory()
 
         schema = Spec.from_dict(
-            {"x-model-path": "foo.BarModel"}, validator=None
+            {"x-model-path": "foo.BarModel"}, spec_validator_cls=None
         )
         test_model_class = factory.create(schema, ["a", "b"])
 

--- a/tests/unit/schema/test_schema_parameters.py
+++ b/tests/unit/schema/test_schema_parameters.py
@@ -20,7 +20,7 @@ class TestGetStyle:
             "name": "default",
             "in": location,
         }
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         result = get_style(param)
 
         assert result == expected
@@ -45,7 +45,7 @@ class TestGetStyle:
             "in": location,
             "style": style,
         }
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         result = get_style(param)
 
         assert result == style
@@ -69,7 +69,7 @@ class TestGetExplode:
             "in": location,
             "style": style,
         }
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         result = get_explode(param)
 
         assert result is False
@@ -81,7 +81,7 @@ class TestGetExplode:
             "in": location,
             "style": "form",
         }
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         result = get_explode(param)
 
         assert result is True
@@ -117,7 +117,7 @@ class TestGetExplode:
                 "type": schema_type,
             },
         }
-        param = Spec.from_dict(spec, validator=None)
+        param = Spec.from_dict(spec, spec_validator_cls=None)
         result = get_explode(param)
 
         assert result == explode

--- a/tests/unit/security/test_providers.py
+++ b/tests/unit/security/test_providers.py
@@ -32,7 +32,7 @@ class TestHttpProvider:
             "/pets",
             headers=headers,
         )
-        scheme = Spec.from_dict(spec, validator=None)
+        scheme = Spec.from_dict(spec, spec_validator_cls=None)
         provider = HttpProvider(scheme)
 
         result = provider(request.parameters)

--- a/tests/unit/templating/test_media_types_finders.py
+++ b/tests/unit/templating/test_media_types_finders.py
@@ -16,7 +16,7 @@ class TestMediaTypes:
 
     @pytest.fixture(scope="class")
     def content(self, spec):
-        return Spec.from_dict(spec, validator=None)
+        return Spec.from_dict(spec, spec_validator_cls=None)
 
     @pytest.fixture(scope="class")
     def finder(self, content):

--- a/tests/unit/templating/test_paths_finders.py
+++ b/tests/unit/templating/test_paths_finders.py
@@ -124,7 +124,7 @@ class BaseTestSpecServer:
             "servers": servers,
             "paths": paths,
         }
-        return Spec.from_dict(spec, validator=None)
+        return Spec.from_dict(spec, spec_validator_cls=None)
 
     @pytest.fixture
     def finder(self, spec):
@@ -146,7 +146,7 @@ class BaseTestPathServer(BaseTestSpecServer):
             "info": info,
             "paths": paths,
         }
-        return Spec.from_dict(spec, validator=None)
+        return Spec.from_dict(spec, spec_validator_cls=None)
 
 
 class BaseTestOperationServer(BaseTestSpecServer):
@@ -165,7 +165,7 @@ class BaseTestOperationServer(BaseTestSpecServer):
             "info": info,
             "paths": paths,
         }
-        return Spec.from_dict(spec, validator=None)
+        return Spec.from_dict(spec, spec_validator_cls=None)
 
 
 class BaseTestServerNotFound:
@@ -281,7 +281,7 @@ class BaseTestPathsNotFound:
         spec = {
             "info": info,
         }
-        return Spec.from_dict(spec, validator=None)
+        return Spec.from_dict(spec, spec_validator_cls=None)
 
     def test_raises(self, finder):
         method = "get"

--- a/tests/unit/templating/test_responses_finders.py
+++ b/tests/unit/templating/test_responses_finders.py
@@ -18,7 +18,7 @@ class TestResponses:
 
     @pytest.fixture(scope="class")
     def responses(self, spec):
-        return Spec.from_dict(spec, validator=None)
+        return Spec.from_dict(spec, spec_validator_cls=None)
 
     @pytest.fixture(scope="class")
     def finder(self, responses):

--- a/tests/unit/test_paths_spec.py
+++ b/tests/unit/test_paths_spec.py
@@ -1,0 +1,24 @@
+import pytest
+from openapi_spec_validator import openapi_v31_spec_validator
+from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
+from openapi_core import Spec
+
+
+class TestSpecFromDict:
+    def test_validator(self):
+        schema = {}
+
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(OpenAPIValidationError):
+                Spec.from_dict(schema, validator=openapi_v31_spec_validator)
+
+    def test_validator_none(self):
+        schema = {}
+
+        with pytest.warns(DeprecationWarning):
+            Spec.from_dict(schema, validator=None)
+
+    def test_spec_validator_cls_none(self):
+        schema = {}
+
+        Spec.from_dict(schema, spec_validator_cls=None)

--- a/tests/unit/unmarshalling/test_schema_unmarshallers.py
+++ b/tests/unit/unmarshalling/test_schema_unmarshallers.py
@@ -56,7 +56,7 @@ class TestOAS30SchemaUnmarshallerFactoryCreate:
             "type": "string",
             "format": unknown_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(FormatterNotFoundError):
             unmarshaller_factory(spec)
@@ -67,7 +67,7 @@ class TestOAS30SchemaUnmarshallerFactoryCreate:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(
             FormatterNotFoundError,
@@ -88,7 +88,7 @@ class TestOAS30SchemaUnmarshallerUnmarshal:
             "type": "string",
             "format": "custom",
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         value = "x"
         schema_validators_factory = SchemaValidatorsFactory(
             OAS30WriteValidator
@@ -118,7 +118,7 @@ class TestOAS30SchemaUnmarshallerUnmarshal:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         value = "x"
         schema_validators_factory = SchemaValidatorsFactory(
             OAS30WriteValidator
@@ -147,7 +147,7 @@ class TestOAS30SchemaUnmarshallerUnmarshal:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         value = "x"
         schema_validators_factory = SchemaValidatorsFactory(
             OAS30WriteValidator
@@ -175,7 +175,7 @@ class TestOAS30SchemaUnmarshallerUnmarshal:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         value = "x"
         schema_validators_factory = SchemaValidatorsFactory(
             OAS30WriteValidator
@@ -208,7 +208,7 @@ class TestOAS30SchemaUnmarshallerUnmarshal:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         value = "x"
         schema_validators_factory = SchemaValidatorsFactory(
             OAS30WriteValidator
@@ -235,7 +235,7 @@ class TestOAS30SchemaUnmarshallerUnmarshal:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         value = "x"
         schema_validators_factory = SchemaValidatorsFactory(
             OAS30WriteValidator

--- a/tests/unit/validation/test_schema_validators.py
+++ b/tests/unit/validation/test_schema_validators.py
@@ -21,7 +21,7 @@ class TestSchemaValidate:
             "type": "string",
             "format": custom_format,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
         value = "x"
 
         validator_factory(spec).validate(value)
@@ -32,7 +32,7 @@ class TestSchemaValidate:
             "type": "integer",
             "minimum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -43,7 +43,7 @@ class TestSchemaValidate:
             "type": "integer",
             "minimum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 
@@ -55,7 +55,7 @@ class TestSchemaValidate:
             "type": "integer",
             "maximum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -66,7 +66,7 @@ class TestSchemaValidate:
             "type": "integer",
             "maximum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 
@@ -78,7 +78,7 @@ class TestSchemaValidate:
             "type": "integer",
             "multipleOf": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -89,7 +89,7 @@ class TestSchemaValidate:
             "type": "integer",
             "multipleOf": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 
@@ -101,7 +101,7 @@ class TestSchemaValidate:
             "type": "number",
             "minimum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -112,7 +112,7 @@ class TestSchemaValidate:
             "type": "number",
             "minimum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 
@@ -125,7 +125,7 @@ class TestSchemaValidate:
             "minimum": 3,
             "exclusiveMinimum": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -137,7 +137,7 @@ class TestSchemaValidate:
             "minimum": 3,
             "exclusiveMinimum": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 
@@ -149,7 +149,7 @@ class TestSchemaValidate:
             "type": "number",
             "maximum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -160,7 +160,7 @@ class TestSchemaValidate:
             "type": "number",
             "maximum": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 
@@ -173,7 +173,7 @@ class TestSchemaValidate:
             "maximum": 3,
             "exclusiveMaximum": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -185,7 +185,7 @@ class TestSchemaValidate:
             "maximum": 3,
             "exclusiveMaximum": True,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 
@@ -197,7 +197,7 @@ class TestSchemaValidate:
             "type": "number",
             "multipleOf": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         with pytest.raises(InvalidSchemaValue):
             validator_factory(spec).validate(value)
@@ -208,7 +208,7 @@ class TestSchemaValidate:
             "type": "number",
             "multipleOf": 3,
         }
-        spec = Spec.from_dict(schema, validator=None)
+        spec = Spec.from_dict(schema, spec_validator_cls=None)
 
         result = validator_factory(spec).validate(value)
 


### PR DESCRIPTION
Move from `validator` to `cis` for openapi -spec-validator

Fixes #715