### PR TITLE
Fix `MockRequest.body` type

### DIFF
--- a/openapi_core/testing/requests.py
+++ b/openapi_core/testing/requests.py
@@ -31,7 +31,7 @@ class MockRequest:
         self.view_args = view_args
         self.headers = headers
         self.cookies = cookies
-        self.body = data or ""
+        self.body = data or b""
         self.content_type = content_type
 
         self.parameters = RequestParameters(


### PR DESCRIPTION
Commit 0031ff74c04146fa6ba91925a7f54e0d5f7b2159 changed `data` from `str` to `bytes`, but forgot to adjust this default value.