### PR TITLE
Fix a DeprecationWarning from aiohttp in TestPetPhotoView

### DIFF
--- a/tests/integration/contrib/aiohttp/test_aiohttp_project.py
+++ b/tests/integration/contrib/aiohttp/test_aiohttp_project.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from base64 import b64encode
+from io import BytesIO
 
 import pytest
 
@@ -63,7 +64,7 @@ class TestPetPhotoView(BaseTestPetstore):
             "Host": "petstore.swagger.io",
         }
         data = {
-            "file": data_gif,
+            "file": BytesIO(data_gif),
         }
 
         cookies = {"user": "1"}


### PR DESCRIPTION
The warning says, “In v4, passing bytes will no longer create a file field. Please explicitly use the filename parameter or pass a BytesIO object.” This commit implements the latter approach.