### PR TITLE
Validation crashes on BooleanCaster: AttributeError: 'int' object has…

### DIFF
--- a/openapi_core/casting/schemas/casters.py
+++ b/openapi_core/casting/schemas/casters.py
@@ -74,7 +74,10 @@ class BooleanCaster(PrimitiveTypeCaster[bool]):
         if isinstance(value, bool):
             return
 
-        if value.lower() not in ["false", "true"]:
+        if (
+            not isinstance(value, (str, bytes)) or
+            value.lower() not in ["false", "true"]
+        ):
             raise ValueError("not a boolean format")
 
 


### PR DESCRIPTION
    if value.lower() not in ["false", "true"]:
AttributeError: 'int' object has no attribute 'lower'