### PR TITLE
Adding provision to pass inputs to custom error handler class

### DIFF
--- a/openapi_core/contrib/flask/decorators.py
+++ b/openapi_core/contrib/flask/decorators.py
@@ -34,12 +34,14 @@ class FlaskOpenAPIViewDecorator(FlaskIntegration):
         errors_handler_cls: Type[
             FlaskOpenAPIErrorsHandler
         ] = FlaskOpenAPIErrorsHandler,
+        error_handler_params: dict = None
     ):
         super().__init__(openapi)
         self.request_cls = request_cls
         self.response_cls = response_cls
         self.request_provider = request_provider
         self.errors_handler_cls = errors_handler_cls
+        self.error_handler_params = error_handler_params
 
     def __call__(self, view: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(view)
@@ -48,7 +50,10 @@ class FlaskOpenAPIViewDecorator(FlaskIntegration):
             valid_request_handler = self.valid_request_handler_cls(
                 request, view, *args, **kwargs
             )
-            errors_handler = self.errors_handler_cls()
+            if self.error_handler_params is None:
+                errors_handler = self.errors_handler_cls()
+            else:
+                errors_handler = self.errors_handler_cls(self.error_handler_params)
             response = self.handle_request(
                 request, valid_request_handler, errors_handler
             )
@@ -69,6 +74,7 @@ class FlaskOpenAPIViewDecorator(FlaskIntegration):
         errors_handler_cls: Type[
             FlaskOpenAPIErrorsHandler
         ] = FlaskOpenAPIErrorsHandler,
+        error_handler_params: dict = None
     ) -> "FlaskOpenAPIViewDecorator":
         openapi = OpenAPI(spec)
         return cls(
@@ -77,4 +83,5 @@ class FlaskOpenAPIViewDecorator(FlaskIntegration):
             response_cls=response_cls,
             request_provider=request_provider,
             errors_handler_cls=errors_handler_cls,
+            error_handler_params=error_handler_params
         )


### PR DESCRIPTION
Adding an optional parameter `error_handler_params`  in Flask Decorator to provide data to Error handler class.

The parameter is basically a dictionary which is passed to constructor of error handler class,
and if it is not passed, then nothing is passed in the constructor.

This PR implements following feature request
https://github.com/python-openapi/openapi-core/issues/910

Consider below example for understanding usage of this flag

```
#!/usr/bin/python3
"""Test server."""

from flask import Flask, request, jsonify
from openapi_core.contrib.flask.decorators import FlaskOpenAPIViewDecorator, FlaskOpenAPIErrorsHandler
from openapi_core import Spec

# Custom Error Handler block
class MyCustomErrorHandler(FlaskOpenAPIErrorsHandler):
    """"Custom Error Handler"""
    def __init__(self, input_param:dict):
        self.title =  input_param.get("title")

    def handle(self, errors:list):
        response_object =  jsonify({
            "title": self.title,
            "causedBy" : [self.handle_error(error) for error in errors]
        })
        response_object.error_code = 400
        return response_object

    def handle_error(self, error):
        """
        Converts error object into error string message

        :param error: Error object which stores exception message
        :type error: Exception object
        :return: Error message string corresponding to error object
        :rtype: str
        """
        if error.__cause__ is not None:
            error = error.__cause__
        return str(error)

SPEC = "test.yaml"
app = Flask(__name__)

spec_object = Spec.from_file_path(SPEC)
openapi_decorator = FlaskOpenAPIViewDecorator.from_spec(spec_object, openapi_errors_handler=MyCustomErrorHandler, error_handler_params={"title" : "Failed to execute test API"})

@app.route("/test", methods=["POST"])
@openapi_decorator
def read_permission():
    """Test function"""
    temp =  jsonify({
                    "stri_normal_json": request.json.get("flag", 1)
                })
    print(dir(temp))
    return temp

if __name__ == "__main__":
    app.run(host="0.0.0.0", port=345, debug=True)

#Valid request: curl -X POST http://localhost:345/test --data '{"flag":"rohana"}' -H 'Content-Type: application/json'

#Invalid Request: curl -X POST http://localhost:345/test --data '{"flag":"rohan"}' -H 'Content-Type: application/json'
```

Following is test.yaml

```
openapi: '3.0.2'
info:
  title: Test Title
  version: '1.0'
servers:
  - url: http://localhost:345/
paths:
  /test:
    post:
      requestBody:
        content:
          application/json:
            schema:
              type: object
              required:
                - flag
              properties:
                flag:
                  x-pii: true
                  type: string
                  pattern: "^[\\w.-]*$"
                  minLength: 6
                  maxLength: 20
      responses:
        200:
          description: Sample response
          content:
            application/json:
              schema:
                type: object
                properties:
                  stri_normal_json:
                    type: string
                    minLength: 6
                    maxLength: 20
```


Kindly note the constructor of openapi error handler
```
def __init__(self, input_param:dict):
```

whatever custom input is passed is accessed through input_param parameter.  
int input_param is a dictionary and stores custom data in custom key/value format.

this custom input can be passed whenever we create new openapi_core decorator object as shown in above example
```
FlaskOpenAPIViewDecorator.from_spec(spec_object, openapi_errors_handler=MyCustomErrorHandler, error_handler_params={"title" : "Failed to execute test API"})
```

as we can see the dictionary `{"title" : "Failed to execute test API"}` is passed to error handler constructor and is accessed within the code