### PR TITLE
Allow Starlette 0.45 and 0.46

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3050,4 +3050,4 @@ starlette = ["aioitertools", "starlette"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.0"
-content-hash = "87d982d9b1029063767a0490489e64653b61bc30b3b4e73b629d524c8f254c3a"
+content-hash = "70a19a59886327bec6c3776e7b91ce06f44484e795727c8b5ebdde614ad3472c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ django = {version = ">=3.0", optional = true}
 falcon = {version = ">=3.0", optional = true}
 flask = {version = "*", optional = true}
 aiohttp = {version = ">=3.0", optional = true}
-starlette = {version = ">=0.26.1,<0.45.0", optional = true}
+starlette = {version = ">=0.26.1,<0.47.0", optional = true}
 isodate = "*"
 more-itertools = "*"
 parse = "*"
@@ -104,7 +104,7 @@ pytest-flake8 = "*"
 pytest-cov = "*"
 python-multipart = "*"
 responses = "*"
-starlette = ">=0.26.1,<0.45.0"
+starlette = ">=0.26.1,<0.47.0"
 strict-rfc3339 = "^0.7"
 webob = "*"
 mypy = "^1.2"


### PR DESCRIPTION
Starlette 0.45 drops Python 3.8 support, removes `ExceptionMiddleware` from `starlette.exceptions`, and removes `WS_1004_NO_STATUS_RCVD` and `WS_1005_ABNORMAL_CLOSURE`: https://github.com/encode/starlette/releases/tag/0.45.0

Starlette 0.46 renames `max_file_size` to `spool_max_size` in `MultiPartParser`: https://github.com/encode/starlette/releases/tag/0.46.0

None of that should affect openapi-core.

----

Even with this PR, Starlette would still be stuck at `0.44.0` in `poetry.lock` until openapi-core drops support for Python 3.8.


I didn’t try to drop Python 3.8 support in this PR, but just to check, I tried a local experiment:

```diff
diff --git a/pyproject.toml b/pyproject.toml
index 8132fd5..16369f9 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -60,7 +59,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8.0"
+python = "^3.9.0"
 django = {version = ">=3.0", optional = true}
 falcon = {version = ">=3.0", optional = true}
 flask = {version = "*", optional = true}
```

I then ran `poetry update starlette` and confirmed that the tests do still pass with Starlette 0.46.1.