### PR TITLE
fix: do request body validation before casting

### DIFF
--- a/openapi_core/validation/validators.py
+++ b/openapi_core/validation/validators.py
@@ -249,6 +249,8 @@ class BaseValidator:
             return deserialised, None
 
         schema = media_type / "schema"
+        # Validate the original deserialized value first before casting
+        self._validate_schema(schema, deserialised)
         # cast for urlencoded content
         # FIXME: don't cast data from media type deserializer
         # See https://github.com/python-openapi/openapi-core/issues/706
@@ -261,9 +263,9 @@ class BaseValidator:
         casted, schema = self._get_content_schema_value_and_schema(
             raw, content, mimetype
         )
+        # Validation already happens in _get_content_schema_value_and_schema for schemas
         if schema is None:
             return casted, None
-        self._validate_schema(schema, casted)
         return casted, schema
 
     def _get_media_type_value(

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -1689,7 +1689,7 @@ class TestPetstore:
                 spec=spec,
                 cls=V30RequestBodyValidator,
             )
-        assert type(exc_info.value.__cause__) is CastError
+        assert type(exc_info.value.__cause__) is InvalidSchemaValue
 
     def test_post_tags_additional_properties(self, spec):
         host_url = "http://petstore.swagger.io/v1"


### PR DESCRIPTION
Before this change I was getting `CastError` instead of `InvalidSchemaField` when passing `"invalid"` to a boolean field. This happened because the library was first doing the casting, which would fail because `"invalid"` cannot be casted to `True` or `False`.